### PR TITLE
fix(cli): preserve <pre> content in --format html

### DIFF
--- a/test-summary.txt
+++ b/test-summary.txt
@@ -88,7 +88,7 @@ justhtml-tests/tokenizer_edge_cases.test: 35/35 (100%) [........................
 justhtml-tests/treebuilder_coverage.dat: 17/17 (100%) [.................]
 justhtml-tests/xml_coercion.dat: 4/4 (100%) [....]
 justhtml-tests/xml_coercion_coverage.test: 2/2 (100%) [..]
-test_cli.py: 11/11 (100%) [...........]
+test_cli.py: 12/12 (100%) [............]
 test_encoding.py: 9/9 (100%) [.........]
 test_errors.py: 41/41 (100%) [.........................................]
 test_node.py: 70/70 (100%) [......................................................................]
@@ -96,4 +96,4 @@ test_selector.py: 232/232 (100%) [..............................................
 test_serialize.py: 20/20 (100%) [....................]
 test_stream.py: 7/7 (100%) [.......]
 
-PASSED: 9381/9381 passed (100.0%), 13 skipped
+PASSED: 9382/9382 passed (100.0%), 13 skipped

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,14 @@ class TestCLI(unittest.TestCase):
         self.assertIn("world", out)
         self.assertEqual(err, "")
 
+    def test_format_html_preserves_preformatted_text(self):
+        html = "<pre><code>a</code>-&gt;<code>b</code></pre>"
+        code, out, err = self._run_cli(["-", "--format", "html"], stdin_text=html)
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        # Pretty-printing should not inject whitespace/newlines inside <pre>.
+        self.assertIn("</code>-&gt;<code>", out)
+
     def test_stdin_non_utf8_bytes_does_not_crash(self):
         stdout = StringIO()
         stderr = StringIO()


### PR DESCRIPTION
Avoid introducing whitespace/newlines inside preformatted elements when pretty-printing HTML output.

(fixes #11)