### PR TITLE
Fix raw-text end-tag scan misalignment after length-changing-case characters

### DIFF
--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -708,7 +708,10 @@ class ParseEngine:
     ) -> None:
         self._html_input = html
         self._length = len(html)
-        self._lower_input = html.lower()
+        # ASCII-only fold: positions in self._html_input are reused against
+        # self._lower_input, so the fold must be length-preserving
+        # (str.lower() is not, e.g. for U+0130).
+        self._lower_input = _scanner.ascii_lower(html)
         self._fragment = bool(fragment)
         self._collect_errors = bool(collect_errors)
         self._errors: list[ParseError] = []

--- a/src/justhtml/parser/scanner.py
+++ b/src/justhtml/parser/scanner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import string
+
 SPACE = " \t\n\f\r"
 TAG_NAME_STOP = "\t\n\f />"
 # In the HTML attribute-name state, quotes, apostrophes, "<", and NUL are
@@ -7,6 +9,32 @@ TAG_NAME_STOP = "\t\n\f />"
 ATTR_NAME_STOP = "\t\n\f />="
 ATTR_VALUE_STOP = SPACE + ">"
 TAG_END_NAME_STOP = SPACE + "/>"
+
+_ASCII_LOWER_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+
+def ascii_lower(html: str) -> str:
+    """Fold the input for ASCII case-insensitive scanning, index-aligned.
+
+    The folded copy is searched for ASCII needles with positions taken from
+    the original string, so the fold must behave like lowercasing only A-Z
+    (markup matching is ASCII case-insensitive per §13.2.5) and must be
+    length-preserving. str.lower() alone is neither: "İ" (U+0130) lowers to
+    two characters, shifting every later index, and U+212A KELVIN SIGN lowers
+    to "k", over-matching ASCII needles.
+
+    str.lower() is still used as the fast path: when it preserves the total
+    length, every character mapped one-to-one, so indexes stay aligned, and
+    with U+212A absent no non-ASCII character can produce an ASCII needle
+    character. The strict A-Z table fold only runs for the rare inputs that
+    fail those checks.
+    """
+    if html.isascii():
+        return html.lower()
+    lowered = html.lower()
+    if len(lowered) != len(html) or "\u212a" in html:
+        return html.translate(_ASCII_LOWER_TABLE)
+    return lowered
 
 
 def find_tag_end(html: str, pos: int, end: int) -> int:

--- a/src/justhtml/parser/stream.py
+++ b/src/justhtml/parser/stream.py
@@ -60,7 +60,10 @@ class _StreamScanner:
 
     def __init__(self, html: str) -> None:
         self._html = html
-        self._lower = html.lower()
+        # ASCII-only fold: positions in self._html are reused against
+        # self._lower, so the fold must be length-preserving (str.lower() is
+        # not, e.g. for U+0130).
+        self._lower = _scanner.ascii_lower(html)
         self._open_elements = []
 
     def scan(self) -> Generator[StreamEvent, None, None]:

--- a/tests/test_parser_regressions.py
+++ b/tests/test_parser_regressions.py
@@ -77,5 +77,47 @@ class TestEngineBehaviorRegressions(unittest.TestCase):
         assert document.to_html(pretty=False) == "&lt;!--c--&gt;<p>x</p>"
 
 
+class TestAsciiCaseFoldingRegressions(unittest.TestCase):
+    """The lowered scan copy must stay index-aligned with the original input.
+
+    "İ" (U+0130) is the only character whose str.lower() expands to two
+    characters, shifting every later index of a Unicode-lowered copy. Markup
+    matching is ASCII case-insensitive per §13.2.5, so only A-Z may fold.
+    """
+
+    def test_rawtext_end_tag_found_after_length_changing_case_char(self) -> None:
+        cases = [
+            # Before the raw-text element.
+            "<div>İ</div><script>y</script>0",
+            "<div>İ</div><title>y</title>0",
+            "<div>İ</div><textarea>a</textarea>b",
+            "<div>İİİ</div><style>.a{}</style>tail",
+            # Inside the raw-text content itself.
+            '<script>var x = "İ";</script>0',
+        ]
+
+        for html in cases:
+            with self.subTest(html=html):
+                assert JustHTML(html, fragment=True, sanitize=False).to_html(pretty=False) == html
+
+    def test_kelvin_sign_document_scans_with_strict_ascii_fold(self) -> None:
+        # U+212A KELVIN SIGN is the only non-ASCII character whose str.lower()
+        # is an ASCII letter ("k"), so it must take the strict A-Z fold and
+        # come through scanning untouched.
+        html = "<div>\u212a</div><script>y</script>0"
+
+        assert JustHTML(html, fragment=True, sanitize=False).to_html(pretty=False) == html
+
+    def test_doctype_after_length_changing_case_char_is_not_a_comment(self) -> None:
+        document = JustHTML("İ<!DOCTYPE html><p>x</p>", sanitize=False)
+
+        assert document.to_html(pretty=False) == "<html><head></head><body>İ<p>x</p></body></html>"
+
+    def test_foreign_cdata_after_length_changing_case_char_stays_text(self) -> None:
+        document = JustHTML("<svg>İ<![CDATA[x]]></svg>", fragment=True, sanitize=False)
+
+        assert document.to_html(pretty=False) == "<svg>İx</svg>"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -405,3 +405,37 @@ class TestStream(unittest.TestCase):
 
         invalid_quoted = '<!--<script X </script foo="</scriptx">tail</script>'
         assert find_script_end_tag(invalid_quoted, invalid_quoted.lower(), 0, len(invalid_quoted)) == (43, 52)
+
+    def test_rawtext_end_tag_after_length_changing_case_char(self):
+        # "İ" (U+0130) lowers to two characters, so a str.lower() copy of the
+        # input drifts out of index alignment with the original. The rawtext
+        # scan must keep finding the real end tag after such a character.
+        assert list(stream("<div>İ</div><script>y</script>0")) == [
+            ("start", ("div", {})),
+            ("text", "İ"),
+            ("end", "div"),
+            ("start", ("script", {})),
+            ("text", "y"),
+            ("end", "script"),
+            ("text", "0"),
+        ]
+        assert list(stream('<script>var x = "İ";</script>0')) == [
+            ("start", ("script", {})),
+            ("text", 'var x = "İ";'),
+            ("end", "script"),
+            ("text", "0"),
+        ]
+
+    def test_doctype_after_length_changing_case_char(self):
+        assert list(stream("İ<!DOCTYPE html>")) == [
+            ("text", "İ"),
+            ("doctype", ("html", None, None)),
+        ]
+
+    def test_foreign_cdata_after_length_changing_case_char(self):
+        assert list(stream("<svg>İ<![CDATA[x]]></svg>")) == [
+            ("start", ("svg", {})),
+            ("text", "İ"),
+            ("text", "x"),
+            ("end", "svg"),
+        ]


### PR DESCRIPTION
## The bug

```python
from justhtml import JustHTML
JustHTML('<div>İ</div><script>y</script>0', fragment=True, sanitize=False).to_html(pretty=False)
# actual:   '<div>İ</div><script>y&lt;/script>0</script>'   (close tag swallowed into script text)
# expected: '<div>İ</div><script>y</script>0'                (what browsers and html5lib produce)
```

Both scan paths build a full lowercased copy of the input and reuse positions across the original and lowered strings:

- `src/justhtml/parser/stream.py:63` — `self._lower = html.lower()`, searched with original-string positions by `_scanner.find_script_end_tag` / `find_rawtext_end_tag` (`stream.py:352-353`) and by the `doctype` / `[cdata[` `startswith` checks.
- `src/justhtml/parser/engine.py:711` — `self._lower_input = html.lower()`, with the same index-sharing pattern in the rawtext/script scans (`engine.py:4315-4322`), the `<!doctype` / `<![cdata[` / `<frameset` `startswith` checks, `_append_misc_node`'s `rfind`, and `_script_eof_keeps_shell`.

Python's Unicode `str.lower()` is not length-preserving: `"İ"` (U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE) lowers to `"i"` + U+0307 (two characters). Once any such character appears in a document, every later index differs between `_html` and `_lower`, and all of the scans above land at the wrong offset. Besides the `<script>`/`<style>`/`<title>`/`<textarea>` end-tag misses, a doctype or foreign-content CDATA section appearing after such a character degrades into a bogus comment:

```python
JustHTML('İ<!DOCTYPE html><p>x</p>', sanitize=False)          # inserted a <!--DOCTYPE html--> comment node
JustHTML('<svg>İ<![CDATA[x]]></svg>', fragment=True, ...)     # produced <svg>İ<!--[CDATA[x]]--></svg> instead of <svg>İx</svg>
```

All verified against html5lib and browser behavior.

## The fix

Per WHATWG §13.2.5, markup matching is ASCII case-insensitive, so the lowered copy must fold only A-Z — which is also length-preserving by construction. This PR adds `ascii_lower()` to `parser/scanner.py` (the shared low-level scanning module) and uses it for both `stream.py:_lower` and `engine.py:_lower_input`, fixing every consumer at once.

To keep the hot path fast, `str.lower()` is still used whenever it is provably index-safe:

- ASCII input (`str.isascii()` is O(1) on CPython): plain `lower()`, unchanged.
- Non-ASCII input: `lower()` plus two cheap guards — if the total length is unchanged, every character mapped one-to-one (no lowercase mapping shrinks), so indexes stay aligned; and if U+212A KELVIN SIGN is absent (the only non-ASCII character whose `lower()` is an ASCII letter, `"k"`), no fold can create a spurious ASCII needle match.
- Only inputs failing those checks (containing U+0130 or U+212A) take a strict `str.translate` A-Z fold.

## Tests

- `tests/test_parser_regressions.py`: new `TestAsciiCaseFoldingRegressions` — rawtext end-tag scans with U+0130 before the element and inside its text (script/title/textarea/style), the doctype-degrades-to-comment case, the SVG CDATA case, and a U+212A document exercising the strict-fold path.
- `tests/test_stream.py`: the same three shapes at the stream-event level.

Full suite: 3507/3512 passed — the 5 failures (`html5test-com.dat` 23/24, `tests1.dat` 108/112 under the CI-pinned html5lib-tests fixtures) are pre-existing on `main` (current CI is red on the same Tests & Coverage hook). Ruff check/format, mypy, and the html5lib parser-differential gate (`--fail-under-rate 1.0`) all pass; coverage on the changed files is 100% including the new branches.

## Benchmark

`benchmarks/performance.py --iterations 3 --limit 1000 --parsers justhtml --no-mem` on web100k batch 001 (156 MB): 11.03s / 11.04s with the fix vs 11.05s / 11.14s on `main` — no measurable delta.

Found by a round-trip property test (render → reparse → compare) in a downstream HTML library.