### PR TITLE
fix: pop colgroup on </colgroup> in template insertion mode

### DIFF
--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -4083,6 +4083,12 @@ class ParseEngine:
                 return True
         if mode == _TEMPLATE_MODE_COLGROUP:
             if name == "colgroup":
+                # "In column group" </colgroup>: pop the current colgroup, then
+                # switch to "in table" (mirrors the start-tag path above and the
+                # non-template rule). Without the pop the colgroup stays open and
+                # the next start tag (e.g. <script>) is misparented into it.
+                if len(self._stack) > 1 and self._stack[-1].name == "colgroup":
+                    self._stack.pop()
                 self._set_current_template_mode(_TEMPLATE_MODE_TABLE)
                 return True
             return name != "template"

--- a/tests/justhtml-tests/template_recovery.dat
+++ b/tests/justhtml-tests/template_recovery.dat
@@ -1,0 +1,30 @@
+#data
+<template><table><colgroup></colgroup><script></script></table></template>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+
+#document
+| <html>
+|   <head>
+|     <template>
+|       content
+|         <table>
+|           <colgroup>
+|           <script>
+|   <body>
+
+#data
+<template><table><colgroup></colgroup><template></template></table></template>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+
+#document
+| <html>
+|   <head>
+|     <template>
+|       content
+|         <table>
+|           <colgroup>
+|           <template>
+|             content
+|   <body>


### PR DESCRIPTION
## Bug

Inside a `<template>`, a `</colgroup>` end tag switches the template insertion mode back to *in table* but never pops the `colgroup` off the open-elements stack. The next start tag is then inserted into the still-open `colgroup` instead of the table.

Minimal reproducer:

```html
<template><table><colgroup></colgroup><script></script></table></template>
```

**JustHTML (before):**
```
template
  content
    table
      colgroup
        script      ← misparented into the colgroup
```

**Chromium and html5lib (correct):**
```
template
  content
    table
      colgroup
      script        ← sibling of colgroup
```

Section/row start tags happen to clear the stale `colgroup` (via `del self._stack[table_idx + 1:]`), which is why only a following script-supporting element (`<script>` / `<template>`) exposes it. It only occurs inside a template — the same markup at document level already parses correctly, because the non-template *in column group* end-tag rule pops the colgroup.

## Fix

Pop the current `colgroup` before switching to *in table*, mirroring the start-tag path in `_handle_template_mode_start` (which already pops on the mode transition) and the HTML Standard's *in column group* `</colgroup>` rule ("pop the current node, switch to in table"):

```python
if name == "colgroup":
    if len(self._stack) > 1 and self._stack[-1].name == "colgroup":
        self._stack.pop()
    self._set_current_template_mode(_TEMPLATE_MODE_TABLE)
    return True
```

## Tests

Adds `tests/justhtml-tests/template_recovery.dat` with two cases (a trailing `<script>` and a trailing `<template>` after `</colgroup>`), whose expected trees match Chromium and html5lib. They fail on `main` (0/2) and pass with the fix (2/2). The rest of the `justhtml` tree-construction suite is unchanged (56/56).