### PR TITLE
Warm the default sanitizer policy cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Warm the default sanitizer transform cache when compiling the default safe parser plan.
+
 ## [3.6.1] - 2026-07-13
 
 ### Fixed

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -521,6 +521,7 @@ def compile_default_engine_plan(*, fragment: bool, scripting_enabled: bool = Tru
 
     policy = DEFAULT_POLICY if fragment else DEFAULT_DOCUMENT_POLICY
     plan = compile_engine_plan(policy=policy, fragment=fragment, scripting_enabled=scripting_enabled)
+    policy.compile()
     _DEFAULT_ENGINE_PLAN_CACHE[cache_key] = plan
     return plan
 


### PR DESCRIPTION
## What changed

This warms the default sanitizer transform cache when the default safe parser plan is compiled.

## Why

The parser's default safe path compiles and caches an engine plan, but it currently leaves `DEFAULT_POLICY._compiled_sanitize_transforms` as `None`. That breaks the existing cache immutability regression in `tests/test_sanitize.py`, and means callers/tests that inspect the policy cache after a normal safe parse see an uncompiled state even though the default sanitizer path has already been prepared.

## Validation

- `python -m pytest tests\test_sanitize.py::TestSanitizePlumbing::test_default_policy_compiled_sanitize_cache_is_immutable -q`
- `python -m pytest tests\test_sanitize.py::TestSanitizePlumbing -q`
- `python -m pytest tests\test_sanitize.py -q`
- `python -m py_compile src\justhtml\parser\engine.py`
- `git diff --check`

I also ran `python -m pytest tests -q` after installing the package editable. The run reached 1358 passing tests, with unrelated local/environment failures: Windows temp-file locking in CLI tests, locale decoding of docs on this Windows locale, missing external html5lib tree fixtures, and the cache regression fixed here.