### PR TITLE
Handle sibling-aware block edge trimming

### DIFF
--- a/src/justhtml/transforms/runtime.py
+++ b/src/justhtml/transforms/runtime.py
@@ -321,12 +321,16 @@ def apply_compiled_transforms(
                     return text_data
                 if parent_name.lower() not in block_tags:
                     return text_data
+                
+                def _is_block_sibling(sib: Node) -> bool:
+                    name = sib.name
+                    return not name.startswith("#") and name.lower() in block_tags
 
-                if child_index == 0:
-                    text_data = text_data.lstrip(" \t\n\f\r")
-                if child_index == len(children) - 1:
-                    text_data = text_data.rstrip(" \t\n\f\r")
-                return text_data
+               if child_index == 0 or _is_block_sibling(children[child_index - 1]):
+                   text_data = text_data.lstrip(" \t\n\f\r")
+               if child_index == len(children) - 1 or _is_block_sibling(children[child_index + 1]):
+                   text_data = text_data.rstrip(" \t\n\f\r")
+               return text_data
 
             def apply_to_children(
                 parent: Node,

--- a/src/justhtml/transforms/runtime.py
+++ b/src/justhtml/transforms/runtime.py
@@ -321,16 +321,16 @@ def apply_compiled_transforms(
                     return text_data
                 if parent_name.lower() not in block_tags:
                     return text_data
-                
+
                 def _is_block_sibling(sib: Node) -> bool:
                     name = sib.name
                     return not name.startswith("#") and name.lower() in block_tags
 
-               if child_index == 0 or _is_block_sibling(children[child_index - 1]):
-                   text_data = text_data.lstrip(" \t\n\f\r")
-               if child_index == len(children) - 1 or _is_block_sibling(children[child_index + 1]):
-                   text_data = text_data.rstrip(" \t\n\f\r")
-               return text_data
+                if child_index == 0 or _is_block_sibling(children[child_index - 1]):
+                    text_data = text_data.lstrip(" \t\n\f\r")
+                if child_index == len(children) - 1 or _is_block_sibling(children[child_index + 1]):
+                    text_data = text_data.rstrip(" \t\n\f\r")
+                return text_data
 
             def apply_to_children(
                 parent: Node,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1931,6 +1931,22 @@ class TestTransforms(unittest.TestCase):
         )
         assert doc.to_html(pretty=False) == "<p><b>a</b> middle <i>b</i></p>"
 
+    def test_collapsewhitespace_trims_text_adjacent_to_block_siblings(self) -> None:
+        doc = JustHTML(
+            "<div>before <p>middle</p> after</div>",
+            fragment=True,
+            transforms=[CollapseWhitespace()],
+        )
+        assert doc.to_html(pretty=False) == "<div>before<p>middle</p>after</div>"
+
+    def test_collapsewhitespace_preserves_text_adjacent_to_inline_siblings(self) -> None:
+        doc = JustHTML(
+            "<div>before <span>middle</span> after</div>",
+            fragment=True,
+            transforms=[CollapseWhitespace()],
+        )
+        assert doc.to_html(pretty=False) == "<div>before <span>middle</span> after</div>"
+
     def test_collapsewhitespace_block_tags_can_include_custom_tags(self) -> None:
         doc = JustHTML(
             "<x-card>\n      test\n</x-card>",


### PR DESCRIPTION
A block-level sibling ends the anonymous inline box, and line-box edge whitespace never renders — so `"text <p>a</p>"` trims the trailing space exactly like a browser lays it out.