### PR TITLE
Splice DocumentFragment children during DOM insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `append_child()`, `insert_before()`, and `replace_child()` splice `DocumentFragment` children into the target and empty the fragment, matching DOM behavior.
+
 ## [3.9.0] - 2026-07-20
 
 ### Performance

--- a/docs/api.md
+++ b/docs/api.md
@@ -412,6 +412,8 @@ If `node` already has a parent, it is moved from that parent to this node. Use
 `node.clone_node(deep=True)` before appending when you want to keep the source
 DOM unchanged.
 
+Passing a `DocumentFragment` to `append_child`, `insert_before`, or `replace_child` inserts its children in order and leaves the fragment empty. Replacing a node with an empty fragment removes the node.
+
 #### `insert_before(node, reference_node)`
 
 Insert `node` before `reference_node` (or append if `reference_node` is `None`).

--- a/src/justhtml/dom/__init__.py
+++ b/src/justhtml/dom/__init__.py
@@ -175,10 +175,14 @@ class Node:
             self.attrs = attrs if attrs is not None else {}
 
     def append_child(self, node: NodeType) -> None:
-        if self.children is not None:
-            self._adopt_child(node)
-            self.children.append(node)
-            node.parent = self
+        if self.children is None:
+            return
+        if isinstance(node, DocumentFragment):
+            self._insert_fragment(node, None)
+            return
+        self._adopt_child(node)
+        self.children.append(node)
+        node.parent = self
 
     def _adopt_child(self, node: NodeType) -> tuple[Node | None, int | None]:
         if node is self:
@@ -210,6 +214,17 @@ class Node:
                 old_children.pop(old_index)
         node.parent = None
         return old_parent, old_index
+
+    def _insert_fragment(self, fragment: DocumentFragment, reference_node: NodeType | None) -> None:
+        self._adopt_child(fragment)
+        target_children = cast("list[NodeType]", self.children)
+        source_children = cast("list[NodeType]", fragment.children)
+        index = len(target_children) if reference_node is None else target_children.index(reference_node)
+        children = source_children.copy()
+        source_children.clear()
+        for child in children:
+            child.parent = self
+        target_children[index:index] = children
 
     @property
     def _source_html(self) -> str | None:
@@ -419,6 +434,10 @@ class Node:
         except ValueError:
             raise ValueError("Reference node is not a child of this node") from None
 
+        if isinstance(node, DocumentFragment):
+            self._insert_fragment(node, reference_node)
+            return
+
         old_parent, old_index = self._adopt_child(node)
         if old_parent is self and old_index is not None and old_index < index:
             index -= 1
@@ -448,6 +467,11 @@ class Node:
             raise ValueError("The node to be replaced is not a child of this node") from None
 
         if new_node is old_node:
+            return old_node
+
+        if isinstance(new_node, DocumentFragment):
+            self._insert_fragment(new_node, old_node)
+            self.remove_child(old_node)
             return old_node
 
         old_parent, old_index = self._adopt_child(new_node)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -131,6 +131,22 @@ class TestNode(unittest.TestCase):
         assert child.parent is new_parent
         assert child in new_parent.children
 
+    def test_append_child_splices_document_fragment(self):
+        parent = Node("div")
+        fragment = DocumentFragment()
+        first = Node("span", attrs={"id": "1"})
+        second = Node("span", attrs={"id": "2"})
+        fragment.append_child(first)
+        fragment.append_child(second)
+
+        parent.append_child(fragment)
+
+        assert parent.children == [first, second]
+        assert first.parent is parent
+        assert second.parent is parent
+        assert fragment.children == []
+        assert fragment.parent is None
+
     def test_remove_child_noop_for_comment_node(self):
         parent = Comment(data="comment")
         child = Node("span")
@@ -914,6 +930,24 @@ class TestNode(unittest.TestCase):
 
         assert parent.children == [child2, child1, child3]
 
+    def test_insert_before_splices_document_fragment(self):
+        parent = Node("div")
+        reference = Node("p")
+        parent.append_child(reference)
+        fragment = DocumentFragment()
+        first = Node("span", attrs={"id": "1"})
+        second = Node("span", attrs={"id": "2"})
+        fragment.append_child(first)
+        fragment.append_child(second)
+
+        parent.insert_before(fragment, reference)
+
+        assert parent.children == [first, second, reference]
+        assert first.parent is parent
+        assert second.parent is parent
+        assert fragment.children == []
+        assert fragment.parent is None
+
     def test_insert_before_no_children_allowed(self):
         comment = Comment(data="foo")
         node = Node("div")
@@ -944,6 +978,35 @@ class TestNode(unittest.TestCase):
         assert parent.children == [new_child, child2]
         assert new_child.parent == parent
         assert child1.parent is None
+
+    def test_replace_child_splices_document_fragment(self):
+        parent = Node("div")
+        before = Node("span", attrs={"id": "before"})
+        old = Node("p")
+        after = Node("span", attrs={"id": "after"})
+        parent.append_child(before)
+        parent.append_child(old)
+        parent.append_child(after)
+        fragment = DocumentFragment()
+        first = Node("em")
+        second = Node("strong")
+        fragment.append_child(first)
+        fragment.append_child(second)
+
+        replaced = parent.replace_child(fragment, old)
+
+        assert replaced is old
+        assert parent.children == [before, first, second, after]
+        assert first.parent is parent
+        assert second.parent is parent
+        assert old.parent is None
+        assert fragment.children == []
+        assert fragment.parent is None
+
+        empty = DocumentFragment()
+        assert parent.replace_child(empty, after) is after
+        assert parent.children == [before, first, second]
+        assert after.parent is None
 
     def test_replace_child_invalid(self):
         parent = Node("div")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1137,9 +1137,7 @@ class TestSerialize(unittest.TestCase):
         frag1.append_child(Text("  "))
         frag2 = DocumentFragment()
         frag2.append_child(Text("\n"))
-        div.append_child(frag1)
-        div.append_child(Text(" "))
-        div.append_child(frag2)
+        div.children = [frag1, Text(" "), frag2]
 
         output = div.to_html(pretty=True)
         assert output == "<div> </div>"


### PR DESCRIPTION
## Background

`JustHTML(..., fragment=True)` returns a `DocumentFragment`. DOM insertion methods should splice that fragment's children into the destination and leave the fragment empty. Previously, JustHTML attached the fragment object itself as a child.

Correct fragment insertion is useful when parsed HTML replaces an existing node:

```python
doc = JustHTML("<div><span>old</span></div>", fragment=True, sanitize=False)
parent = doc.root.children[0]
old = parent.children[0]

fragment = JustHTML("<em>one</em><strong>two</strong>", fragment=True, sanitize=False).root
parent.replace_child(fragment, old)

assert parent.to_html(pretty=False) == "<div><em>one</em><strong>two</strong></div>"
assert fragment.children == []
```

This supports parse, transform, and replace workflows without callers manually moving each parsed child. It also matches standard DOM behavior.

## Changes

- `append_child(fragment)` appends the fragment's children in order.
- `insert_before(fragment, reference)` inserts its children before the reference.
- `replace_child(fragment, old)` replaces the old node with its children.
- Replacing with an empty fragment removes the old node.
- The source fragment is emptied and parent pointers are updated.
- Documentation and serializer coverage are updated.

## Tests

- Node and serializer tests: 300 passed.
- Internal parser suite: 262 passed.
- Documentation examples: 3 passed.
- Ruff check and formatting checks passed.

The full pytest run passed 1,404 tests. Its two remaining failures are independent of this change: this checkout lacks the upstream HTML fixtures, and the existing sanitizer-cache assertion also fails in isolation.

Codex prepared this PR under Jeremy Howard's supervision.