### PR TITLE
Avoid quadratic open-element lookups on deep trees

### DIFF
--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -4052,6 +4052,7 @@ class ParseEngine:
 
     def _find_open_index(self, name: str) -> int | None:
         stack = self._stack
+        if isinstance(stack, _CountingStack) and stack.count_of(name) == 0: return None
         for idx in range(len(stack) - 1, 0, -1):
             if stack[idx].name == name:
                 return idx
@@ -4059,6 +4060,7 @@ class ParseEngine:
 
     def _find_open_html_index(self, name: str) -> int | None:
         stack = self._stack
+        if isinstance(stack, _CountingStack) and stack.count_of(name) == 0: return None
         for idx in range(len(stack) - 1, 0, -1):
             node = stack[idx]
             if node.name == name and node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE}:

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -87,6 +87,24 @@ class TestCountingStack(unittest.TestCase):
         stack.append(Element("span", {}, "html"))
         self.assert_counts_match(stack)
 
+    def test_absent_open_element_lookups_use_name_counts(self) -> None:
+        class TrackingStack(_CountingStack):
+            def __init__(self, nodes):
+                super().__init__(nodes)
+                self.queries = []
+
+            def count_of(self, name):
+                self.queries.append(name)
+                return super().count_of(name)
+
+        stack = TrackingStack(Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD))
+        engine = ParseEngine("", fragment=True)
+        engine._stack = stack
+
+        assert engine._find_open_index("table") is None
+        assert engine._find_open_html_index("select") is None
+        assert stack.queries == ["table", "select"]
+
     def test_append_and_insert_activate_name_tracking_at_the_threshold(self) -> None:
         shallow = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD - 1)]
 


### PR DESCRIPTION
Deeply nested ordinary HTML currently makes the parser repeatedly scan the full open-elements stack for names that are not present.

A document containing nested `div` elements reaches this path several times for every start tag. In particular, `_parse_start_tag()` looks for open `select` and `table` elements. Both lookups walk from the top of the stack to the bottom even when neither name occurs anywhere in it. Repeating those absent-name scans at every nesting level makes total parsing time quadratic.

This showed up in a bounded-time Markdown-to-HTML pipeline that uses JustHTML for its final fragment parse. Increasing the test input from 250 nested `div` pairs to 2,000 pairs, an 8x increase, raised end-to-end runtime from about 4.3 ms to 204 ms. Profiling attributed 166 ms of the 229 ms JustHTML parse to the open-element lookup helpers. Serialization took about 5 ms.

JustHTML's `_CountingStack` already tracks element-name counts once the stack becomes deep. `_find_open_index_before_boundary()` uses those counts to return immediately when a target is absent. This PR applies the same zero-count fast path to `_find_open_index()` and `_find_open_html_index()`. A plain-list guard preserves the existing private-helper contract used by the test suite.

The regression test verifies that absent lookups consult the tracked counts. The original bounded-time test passes with the patched source and completes in about 60 ms including both input sizes and Markdown rendering.

Testing:

```text
PYTHONPATH=src pytest -q tests/test_parser_engine.py -k 'not upstream_inputs_across_diagnostic_modes'
53 passed, 1 deselected, 214 subtests passed
```

The excluded diagnostic-mode test requires the cloned html5lib test corpus, which is absent from this checkout.

Codex prepared this PR under Jeremy Howard's supervision.