### PR TITLE
security: Prevent quadratic and recursive work on small HTML inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- Keep parsing, sanitization, deep cloning, pretty serialization, streaming, and diagnostic collection linear for deeply nested or repeatedly misnested adversarial input by indexing parser state and avoiding repeated subtree and sibling walks (thanks @kevin-hua-kraken in #72).
+
+### Security
+
+- (Severity: Low) Bound parser and sanitizer work for crafted deep nesting, foreign-content end tags, active formatting recovery, template cleanup, and nested disallowed wrappers that could previously trigger quadratic processing.
+
 ### Fixed
 
-- Make `append_child()`, `insert_before()`, and `replace_child()` splice `DocumentFragment` children into the target and empty the fragment, matching DOM behavior.
+- Make `append_child()`, `insert_before()`, and `replace_child()` splice `DocumentFragment` children into the target and empty the fragment, matching DOM behavior (thanks @jph00 in #68).
+- Preserve literal text when serializing the legacy raw-text elements `iframe`, `noembed`, `noframes`, and `xmp`, so parsing serialized output recovers the same text (thanks @jph00 in #70).
+- Minimize name-matching attribute values only for boolean attributes, preventing ordinary attributes such as `id="id"` from changing value during serialization (thanks @jph00 in #69).
 
 ## [3.9.0] - 2026-07-20
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -82,6 +82,28 @@ Available modes are `parse`, `fragment`, `compact-html`, `pretty-html`, and
 on functions that dominate cumulative work across many documents, not an
 isolated slow malformed sample.
 
+## Check adversarial scaling
+
+Absolute throughput benchmarks can hide complexity regressions. For parser,
+sanitizer, DOM, and serializer changes, also measure structurally hostile input
+at several sizes and compare the growth per doubling. Linear work should take
+about twice as long when the input doubles; growth approaching four times
+usually indicates a repeated depth or sibling scan.
+
+Focused tests can use `tests.harness.scaling.assert_scales_linearly`:
+
+```python
+assert_scales_linearly(
+    lambda size: "<span>" * size + "x",
+    lambda source: JustHTML(source, sanitize=False),
+)
+```
+
+Pair a hostile shape with a shallow or well-formed control where practical.
+Keep error collection and sanitization settings identical between the shape
+being investigated and its control, because either pipeline can expose a
+different repeated walk.
+
 ## Make a speed improvement
 
 - Preserve parser and sanitizer semantics. Run the parser differential suite
@@ -90,6 +112,9 @@ isolated slow malformed sample.
   attribute projection, and common serialization cases.
 - Prefer direct local data access, reused compiled plans, and fewer temporary
   allocations in per-character and per-node loops.
+- For deep parser state, prefer adaptive indexes that activate only after a
+  fixed depth. This keeps ordinary shallow documents on the simple list path
+  while bounding lookups for hostile nesting.
 - Measure realistic HTML before and after the change. Include a focused
   microbenchmark only when it explains the real-world result.
 - Keep benchmarks honest: warm up once, run multiple iterations, and report

--- a/src/justhtml/dom/__init__.py
+++ b/src/justhtml/dom/__init__.py
@@ -715,10 +715,18 @@ def _clone_subtree_iterative(root: Node) -> Node:
         if not children:
             continue
 
+        target_children = target.children
+        if target_children is None:  # pragma: no cover - child-bearing nodes clone to containers
+            continue
+
         pending: list[tuple[Node, Node]] = []
         for child in children:
             child_clone = child.clone_node(deep=False)
-            target.append_child(child_clone)
+            # Fresh clones are detached and cannot be ancestors of the target.
+            # Appending directly avoids walking the target's ancestors once per
+            # template-bearing descendant during the adoption check.
+            target_children.append(child_clone)
+            child_clone.parent = target
             if isinstance(child, Node) and isinstance(child_clone, Node):
                 pending.append((child, child_clone))
 

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -844,6 +844,20 @@ class _CountingStack(list[Node]):
             return -1
         return max((positions[-1] for positions in self._html_positions.values()), default=-1)
 
+    def last_index_of_any(self, names: Collection[str]) -> int | None:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                if self[index].name in names:
+                    return index
+            return None
+        best = -1
+        for positions_by_name in (self._html_positions, self._other_positions):
+            for name in names:
+                positions = positions_by_name.get(name)
+                if positions:
+                    best = max(best, positions[-1])
+        return best if best > 0 else None
+
     def last_foreign_boundary_index(self) -> int:
         if not self._indexed:
             for index in range(len(self) - 1, 0, -1):
@@ -5800,13 +5814,11 @@ class ParseEngine:
 
     def _has_node_in_scope(self, target: Node, boundaries: frozenset[str]) -> bool:
         stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):  # pragma: no branch - opposite edge requires invalid parser state
-            node = stack[idx]
-            if node is target:
-                return True
-            if node.name in boundaries:
-                return False
-        return False  # pragma: no cover - unreachable after parser-state guards
+        target_index = stack.index_of_node(target)
+        if not target_index:
+            return False
+        boundary_index = stack.last_index_of_any(boundaries)
+        return boundary_index is None or target_index >= boundary_index
 
     def _refresh_active_formatting_dirty(self) -> None:
         active = self._active_formatting

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -735,11 +735,19 @@ class _CountingStack(list[Node]):
     counts so hostile deep nesting retains constant-time negative lookups.
     """
 
-    __slots__ = ("_name_counts", "_p_count")
+    __slots__ = (
+        "_foreign_boundaries",
+        "_html_positions",
+        "_indexed",
+        "_name_counts",
+        "_other_positions",
+        "_p_count",
+    )
 
     def __init__(self, iterable: Iterable[Node] = ()) -> None:
         super().__init__(iterable)
         self._name_counts: dict[str, int] | None = None
+        self._indexed = False
         if len(self) < _STACK_COUNT_THRESHOLD:
             p_count = 0
             for item in self:
@@ -749,6 +757,127 @@ class _CountingStack(list[Node]):
         counts = self._collect_name_counts()
         self._name_counts = counts
         self._p_count = counts.get("p", 0)
+        self._build_position_index()
+
+    def _build_position_index(self) -> None:
+        html: dict[str, list[int]] = {}
+        other: dict[str, list[int]] = {}
+        foreign_boundaries: list[int] = []
+        for index, item in enumerate(self):
+            positions = html if item.namespace in {None, "html"} else other
+            positions.setdefault(item.name, []).append(index)
+            if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and (self._is_foreign_boundary(item)):
+                foreign_boundaries.append(index)
+        self._html_positions = html
+        self._other_positions = other
+        self._foreign_boundaries = foreign_boundaries
+        self._indexed = True
+
+    @staticmethod
+    def _is_foreign_boundary(node: Node) -> bool:
+        if node.namespace == "math" and node.name == "annotation-xml":
+            attrs = node.attrs or {}
+            for name, value in attrs.items():
+                if name.lower() == "encoding":
+                    return (value or "").lower() in {"application/xhtml+xml", "text/html"}
+            return False
+        key = (node.namespace, node.name)
+        return key in HTML_INTEGRATION_POINT_SET or (
+            node.namespace == "math" and key in MATHML_TEXT_INTEGRATION_POINT_SET
+        )
+
+    def last_index_of(self, name: str) -> int | None:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                if self[index].name == name:
+                    return index
+            return None
+        html = self._html_positions.get(name)
+        other = self._other_positions.get(name)
+        index = max(html[-1] if html else 0, other[-1] if other else 0)
+        return index or None
+
+    def last_html_index_of(self, name: str, *, parser_only: bool = False) -> int | None:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                node = self[index]
+                namespaces = {None, "html", _PARSER_ONLY_NAMESPACE} if parser_only else {None, "html"}
+                if node.name == name and node.namespace in namespaces:
+                    return index
+            return None
+        positions = self._html_positions.get(name)
+        best = positions[-1] if positions else 0
+        if parser_only:
+            other = self._other_positions.get(name)
+            if other:
+                for index in reversed(other):
+                    if self[index].namespace == _PARSER_ONLY_NAMESPACE:
+                        best = max(best, index)
+                        break
+        return best or None
+
+    def last_html_index_of_any(self, names: Collection[str]) -> int:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                node = self[index]
+                if node.namespace in {None, "html"} and node.name in names:
+                    return index
+            return -1
+        best = -1
+        for name in names:
+            positions = self._html_positions.get(name)
+            if positions:
+                best = max(best, positions[-1])
+        return best
+
+    def last_foreign_boundary_index(self) -> int:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                node = self[index]
+                if node.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(node):
+                    return index
+            return -1
+        return self._foreign_boundaries[-1] if self._foreign_boundaries else -1
+
+    def last_template_boundary_index(self) -> int:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                node = self[index]
+                if node.name == "template" and (
+                    node.namespace == _PARSER_ONLY_NAMESPACE
+                    or (type(node) is Template and node.namespace in {None, "html"})
+                ):
+                    return index
+            return -1
+        best = -1
+        html = self._html_positions.get("template")
+        if html:
+            for index in reversed(html):
+                if type(self[index]) is Template:
+                    best = index
+                    break
+        other = self._other_positions.get("template")
+        if other:
+            for index in reversed(other):
+                if self[index].namespace == _PARSER_ONLY_NAMESPACE:
+                    best = max(best, index)
+                    break
+        return best
+
+    def _note_top_position(self, item: Node, index: int) -> None:
+        positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
+        positions.setdefault(item.name, []).append(index)
+        if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
+            self._foreign_boundaries.append(index)
+
+    def _forget_top_position(self, item: Node, index: int) -> None:
+        positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
+        bucket = positions[item.name]
+        bucket.pop()
+        if not bucket:
+            del positions[item.name]
+        if self._foreign_boundaries and self._foreign_boundaries[-1] == index:
+            self._foreign_boundaries.pop()
 
     def _collect_name_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
@@ -768,6 +897,7 @@ class _CountingStack(list[Node]):
         return count
 
     def append(self, item: Node) -> None:  # type: ignore[override]
+        index = len(self)
         list.append(self, item)
         name = item.name
         if name == "p":
@@ -775,8 +905,10 @@ class _CountingStack(list[Node]):
         counts = self._name_counts
         if counts is not None:
             counts[name] = counts.get(name, 0) + 1
+            self._note_top_position(item, index)
         elif len(self) >= _STACK_COUNT_THRESHOLD:
             self._name_counts = self._collect_name_counts()
+            self._build_position_index()
 
     def insert(self, index: SupportsIndex, item: Node) -> None:  # type: ignore[override]
         list.insert(self, index, item)
@@ -788,12 +920,16 @@ class _CountingStack(list[Node]):
             counts[name] = counts.get(name, 0) + 1
         elif len(self) >= _STACK_COUNT_THRESHOLD:
             self._name_counts = self._collect_name_counts()
+        if self._indexed:
+            self._build_position_index()
 
     def __setitem__(self, key: SupportsIndex, item: Node) -> None:  # type: ignore[override]
         previous_name = self[key].name
         name = item.name
         list.__setitem__(self, key, item)
         if previous_name == name:
+            if self._indexed:
+                self._build_position_index()
             return
         if previous_name == "p":
             self._p_count -= 1
@@ -803,8 +939,11 @@ class _CountingStack(list[Node]):
         if counts is not None:
             counts[previous_name] -= 1
             counts[name] = counts.get(name, 0) + 1
+        if self._indexed:
+            self._build_position_index()
 
     def pop(self, index: int = -1) -> Node:  # type: ignore[override]
+        normalized_index = index if index >= 0 else len(self) + index
         item = list.pop(self, index)
         name = item.name
         if name == "p":
@@ -812,6 +951,11 @@ class _CountingStack(list[Node]):
         counts = self._name_counts
         if counts is not None:
             counts[name] -= 1
+        if self._indexed:
+            if normalized_index == len(self):
+                self._forget_top_position(item, normalized_index)
+            else:
+                self._build_position_index()
         return item
 
     def remove(self, item: Node) -> None:  # type: ignore[override]
@@ -822,8 +966,16 @@ class _CountingStack(list[Node]):
         counts = self._name_counts
         if counts is not None:
             counts[name] -= 1
+        if self._indexed:
+            self._build_position_index()
 
     def __delitem__(self, key: SupportsIndex | slice) -> None:
+        if isinstance(key, slice):
+            start, stop, step = key.indices(len(self))
+            if self._indexed and step == 1 and stop >= len(self):
+                while len(self) > start:
+                    self.pop()
+                return
         removed = self[key] if isinstance(key, slice) else [self[key]]
         list.__delitem__(self, key)
         p_count = self._p_count
@@ -835,6 +987,8 @@ class _CountingStack(list[Node]):
             if counts is not None:
                 counts[name] -= 1
         self._p_count = p_count
+        if self._indexed:
+            self._build_position_index()
 
 
 class ParseEngine:
@@ -4089,36 +4243,30 @@ class ParseEngine:
 
     def _find_open_index(self, name: str) -> int | None:
         stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):
-            if stack[idx].name == name:
-                return idx
-        return None
+        if type(stack) is list:
+            for index in range(len(stack) - 1, 0, -1):
+                if stack[index].name == name:
+                    return index
+            return None
+        return stack.last_index_of(name)
 
     def _find_open_html_index(self, name: str) -> int | None:
         stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):
-            node = stack[idx]
-            if node.name == name and node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE}:
-                return idx
-        return None
+        if type(stack) is list:
+            for index in range(len(stack) - 1, 0, -1):
+                node = stack[index]
+                if node.name == name and node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE}:
+                    return index
+            return None
+        return stack.last_html_index_of(name, parser_only=True)
 
     def _find_open_index_before_boundary(self, name: str, boundaries: frozenset[str]) -> int | None:
         stack = self._stack
-        if stack.count_of(name) == 0:
+        target = stack.last_index_of(name)
+        if target is None:
             return None
-        for idx in range(len(stack) - 1, 0, -1):
-            node = stack[idx]
-            node_name = node.name
-            if node_name == name:
-                return idx
-            if node.namespace in {None, "html"}:
-                if node_name in boundaries:
-                    return None
-            elif self._is_html_integration_point(node) or self._is_mathml_text_integration_point(  # pragma: no branch
-                node
-            ):
-                return None
-        return None  # pragma: no cover - the count_of fast path above already rules out index 0 as the only match
+        boundary = max(stack.last_html_index_of_any(boundaries), stack.last_foreign_boundary_index())
+        return target if target >= boundary else None
 
     def _find_open_table_scoped_end_index(self, name: str) -> int | None:
         for idx in range(len(self._stack) - 1, 0, -1):
@@ -4133,6 +4281,11 @@ class ParseEngine:
 
     def _find_open_index_in_current_scope(self, name: str) -> int | None:
         stack = self._stack
+        if type(stack) is not list:
+            target = stack.last_index_of(name)
+            if target is None:
+                return None
+            return target if target >= stack.last_template_boundary_index() else None
         for idx in range(len(stack) - 1, 0, -1):
             node = stack[idx]
             if node.name == name:
@@ -4155,18 +4308,12 @@ class ParseEngine:
 
     def _find_open_heading_index(self) -> int | None:
         stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):  # pragma: no branch
-            node = stack[idx]
-            if node.name in HEADING_ELEMENTS:
-                return idx
-            if node.namespace in {None, "html"}:
-                if node.name in _DEFAULT_SCOPE_BOUNDARIES:
-                    return None
-            elif (  # pragma: no branch
-                self._is_html_integration_point(node) or self._is_mathml_text_integration_point(node)
-            ):
-                return None
-        return None
+        target = max((stack.last_index_of(name) or -1 for name in HEADING_ELEMENTS), default=-1)
+        boundary = max(
+            stack.last_html_index_of_any(_DEFAULT_SCOPE_BOUNDARIES),
+            stack.last_foreign_boundary_index(),
+        )
+        return target if target > boundary else None
 
     def _set_current_template_mode(self, mode: str) -> None:
         if self._template_modes:  # pragma: no branch - opposite edge requires invalid parser state

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -6222,46 +6222,48 @@ class ParseEngine:
         return True
 
     def _body_allows_frameset(self, node: Node) -> bool:
-        children = node.children
-        if not children:
-            return True
-        for child in children:
-            if type(child) is Text:
-                if (child.data or "").strip(_SPACE):
-                    return False
+        pending: list[Node] = [node]
+        while pending:
+            children = pending.pop().children
+            if not children:
                 continue
-            namespace = getattr(child, "namespace", None)
-            if namespace == _PARSER_ONLY_NAMESPACE:
-                return False
-            if namespace not in {None, "html"}:
-                if self._foreign_subtree_allows_frameset(child):
+            for child in children:
+                if type(child) is Text:
+                    if (child.data or "").strip(_SPACE):
+                        return False
                     continue
-                return False
-            if child.name == "input":
-                attrs = getattr(child, "attrs", None)
-                input_type = attrs.get("type") if attrs is not None else None
-                if (
-                    isinstance(input_type, str) and input_type.lower() == "hidden"
-                ):  # pragma: no branch - opposite edge requires invalid parser state
-                    continue
-                return False
-            if child.name not in _FRAMESET_BODY_OK_TAGS:
-                return False
-            if not self._body_allows_frameset(child):
-                return False
+                namespace = getattr(child, "namespace", None)
+                if namespace == _PARSER_ONLY_NAMESPACE:
+                    return False
+                if namespace not in {None, "html"}:
+                    if self._foreign_subtree_allows_frameset(child):
+                        continue
+                    return False
+                if child.name == "input":
+                    attrs = getattr(child, "attrs", None)
+                    input_type = attrs.get("type") if attrs is not None else None
+                    if (
+                        isinstance(input_type, str) and input_type.lower() == "hidden"
+                    ):  # pragma: no branch - opposite edge requires invalid parser state
+                        continue
+                    return False
+                if child.name not in _FRAMESET_BODY_OK_TAGS:
+                    return False
+                pending.append(child)
         return True
 
     def _foreign_subtree_allows_frameset(self, node: Node) -> bool:
-        children = node.children
-        if not children:
-            return True
-        for child in children:
-            if type(child) is Text:
-                if (child.data or "").strip(_SPACE + "\ufffd"):
-                    return False
+        pending: list[Node] = [node]
+        while pending:
+            children = pending.pop().children
+            if not children:
                 continue
-            if not self._foreign_subtree_allows_frameset(child):
-                return False
+            for child in children:
+                if type(child) is Text:
+                    if (child.data or "").strip(_SPACE + "\ufffd"):
+                        return False
+                    continue
+                pending.append(child)
         return True
 
     def _append_frameset_text(self, raw: str) -> None:

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -745,6 +745,7 @@ class _CountingStack(list[Node]):
         "_node_positions",
         "_other_positions",
         "_p_count",
+        "_rendered_positions",
     )
 
     def __init__(self, iterable: Iterable[Node] = ()) -> None:
@@ -767,15 +768,19 @@ class _CountingStack(list[Node]):
         other: dict[str, list[int]] = {}
         node_positions: dict[Node, int] = {}
         foreign_boundaries: list[int] = []
+        rendered_positions: list[int] = []
         for index, item in enumerate(self):
             positions = html if item.namespace in {None, "html"} else other
             positions.setdefault(item.name, []).append(index)
             node_positions[item] = index
+            if item.namespace != _PARSER_ONLY_NAMESPACE:
+                rendered_positions.append(index)
             if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and (self._is_foreign_boundary(item)):
                 foreign_boundaries.append(index)
         self._html_positions = html
         self._other_positions = other
         self._foreign_boundaries = foreign_boundaries
+        self._rendered_positions = rendered_positions
         self._node_positions = node_positions
         self._indexed = True
 
@@ -867,6 +872,14 @@ class _CountingStack(list[Node]):
             return -1
         return self._foreign_boundaries[-1] if self._foreign_boundaries else -1
 
+    def last_rendered_index(self) -> int | None:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                if self[index].namespace != _PARSER_ONLY_NAMESPACE:
+                    return index
+            return None
+        return self._rendered_positions[-1] if self._rendered_positions else None
+
     def last_template_boundary_index(self) -> int:
         if not self._indexed:
             for index in range(len(self) - 1, 0, -1):
@@ -896,6 +909,8 @@ class _CountingStack(list[Node]):
         positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
         positions.setdefault(item.name, []).append(index)
         self._node_positions[item] = index
+        if item.namespace != _PARSER_ONLY_NAMESPACE:
+            self._rendered_positions.append(index)
         if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
             self._foreign_boundaries.append(index)
 
@@ -906,6 +921,8 @@ class _CountingStack(list[Node]):
         if not bucket:
             del positions[item.name]
         self._node_positions.pop(item, None)
+        if item.namespace != _PARSER_ONLY_NAMESPACE:
+            self._rendered_positions.pop()
         if self._foreign_boundaries and self._foreign_boundaries[-1] == index:
             self._foreign_boundaries.pop()
 
@@ -916,6 +933,8 @@ class _CountingStack(list[Node]):
         if not bucket:
             del positions[item.name]
         self._node_positions.pop(item, None)
+        if item.namespace != _PARSER_ONLY_NAMESPACE:
+            del self._rendered_positions[bisect_left(self._rendered_positions, index)]
         if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
             del self._foreign_boundaries[bisect_left(self._foreign_boundaries, index)]
 
@@ -940,6 +959,9 @@ class _CountingStack(list[Node]):
             bucket = positions[item.name]
             bucket[bisect_left(bucket, old_position)] = position
             self._node_positions[item] = position
+            if item.namespace != _PARSER_ONLY_NAMESPACE:
+                rendered_index = bisect_left(self._rendered_positions, old_position)
+                self._rendered_positions[rendered_index] = position
             if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
                 boundaries = self._foreign_boundaries
                 boundaries[bisect_left(boundaries, old_position)] = position
@@ -1808,12 +1830,9 @@ class ParseEngine:
         stack = self._stack
         current = stack[-1]
         if current.namespace == _PARSER_ONLY_NAMESPACE:
-            idx = len(stack) - 2
-            while idx > 0:
-                current = stack[idx]
-                if current.namespace != _PARSER_ONLY_NAMESPACE:
-                    break
-                idx -= 1
+            index = stack.last_rendered_index()
+            if index is not None:  # pragma: no branch - parser stack retains a rendered root
+                current = stack[index]
         if type(current) is Template and current.template_content is not None:
             return current.template_content
         return current  # type: ignore[return-value]

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -1404,6 +1404,16 @@ class ParseEngine:
                     self._emit_error("expected-doctype-but-got-chars", first, category="treebuilder")
 
         open_tags: list[str] = []
+        open_tag_positions: dict[str, list[int]] = {}
+
+        def truncate_open_tags(index: int) -> None:
+            for removed_name in reversed(open_tags[index:]):
+                positions = open_tag_positions[removed_name]
+                positions.pop()
+                if not positions:
+                    del open_tag_positions[removed_name]
+            del open_tags[index:]
+
         pos = 0
         while pos < end:
             lt = html.find("<", pos, end)
@@ -1443,15 +1453,11 @@ class ParseEngine:
                 if tag_end == -1:
                     self._emit_error("eof-in-tag", end - 1)
                     return
-                if name == "br" or name not in open_tags:
+                positions = open_tag_positions.get(name)
+                if name == "br" or not positions:
                     self._emit_error("unexpected-end-tag", lt, tag_name=name, category="treebuilder", end_pos=tag_end)
                 else:
-                    for idx in range(
-                        len(open_tags) - 1, -1, -1
-                    ):  # pragma: no branch - opposite edge requires invalid parser state
-                        if open_tags[idx] == name:
-                            del open_tags[idx:]
-                            break
+                    truncate_open_tags(positions[-1])
                 pos = tag_end + 1
                 continue
             if not ch.isalpha():
@@ -1463,13 +1469,20 @@ class ParseEngine:
                 self._emit_error("eof-in-tag", end - 1)
                 return
             if name in _P_CLOSING_START_TAGS:
-                for idx in range(len(open_tags) - 1, -1, -1):
-                    if open_tags[idx] == "p":
-                        del open_tags[idx:]
-                        break
-                    if open_tags[idx] in _P_SCOPE_BOUNDARIES:
-                        break
+                p_positions = open_tag_positions.get("p")
+                if p_positions:
+                    boundary_index = max(
+                        (
+                            positions[-1]
+                            for boundary in _P_SCOPE_BOUNDARIES
+                            if (positions := open_tag_positions.get(boundary))
+                        ),
+                        default=-1,
+                    )
+                    if p_positions[-1] > boundary_index:
+                        truncate_open_tags(p_positions[-1])
             if name not in VOID_ELEMENTS and not self._is_self_closing_source_tag(pos + len(name), tag_end):
+                open_tag_positions.setdefault(name, []).append(len(open_tags))
                 open_tags.append(name)
             pos = tag_end + 1
 

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -1889,7 +1889,6 @@ class ParseEngine:
             ):  # pragma: no cover - one policy cannot make nested templates both parser-only and real
                 parent = parent.template_content
             self._append_text_boundary(parent)
-        self._mark_active_formatting_dirty()
         del self._stack[idx:]
         if node.namespace == _PARSER_ONLY_NAMESPACE:
             self._parser_only_template_depth -= 1
@@ -1899,7 +1898,7 @@ class ParseEngine:
             self._template_modes.pop()
             if not self._template_modes:
                 self._mode_flags &= ~_MODE_TEMPLATE
-        self._clear_active_formatting_to_marker()
+        self._clear_active_formatting_to_marker(refresh=self._active_formatting_dirty)
         return True
 
     def _mark_initial_content(self) -> None:
@@ -5122,7 +5121,7 @@ class ParseEngine:
         self._active_formatting.append(_ACTIVE_FORMATTING_MARKER)
         self._active_formatting_entries.append(_FormattingSegment())
 
-    def _clear_active_formatting_to_marker(self) -> None:
+    def _clear_active_formatting_to_marker(self, *, refresh: bool = True) -> None:
         active = self._active_formatting
         while active:
             entry = active.pop()
@@ -5135,7 +5134,8 @@ class ParseEngine:
             entries = self._active_formatting_entries
             if entries:
                 entries[-1].clear()
-        self._refresh_active_formatting_dirty()
+        if refresh:
+            self._refresh_active_formatting_dirty()
 
     def _foster_parent_for(self, parent: Node, *, for_tag: str | None = None) -> tuple[Node, int] | None:
         # Foster parenting only applies within an HTML table. A foreign element

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -702,14 +702,16 @@ class _FormattingEntry:
 class _FormattingSegment(dict[tuple[str, _FormattingSignature], list[_FormattingEntry]]):
     """One marker-bounded Noah index, with one lazily indexed entry."""
 
-    __slots__ = ("pending",)
+    __slots__ = ("live_names", "pending")
 
     def __init__(self) -> None:
         super().__init__()
         self.pending: _FormattingEntry | None = None
+        self.live_names: dict[str, int] = {}
 
     def clear(self) -> None:
         self.pending = None
+        self.live_names.clear()
         super().clear()
 
 
@@ -3286,6 +3288,8 @@ class ParseEngine:
                         self._nodes_to_unwrap.append(node)
                     entry = _FormattingEntry(name, node.attrs, node, None, entries)
                     self._active_formatting.append(entry)
+                    live = entries.live_names
+                    live[name] = live.get(name, 0) + 1
                     entries.pending = entry
                     return pos
             return self._parse_formatting_start(name, attrs, pos, compiled_safe=True)
@@ -5371,6 +5375,8 @@ class ParseEngine:
             signature_state = _DeferredFormattingSignature(attrs)
         entry = _FormattingEntry(name, node.attrs, node, signature_state, entries)
         self._active_formatting.append(entry)
+        live = entries.live_names
+        live[name] = live.get(name, 0) + 1
         if entries.pending is None and not entries:
             entries.pending = entry
         else:
@@ -5407,11 +5413,14 @@ class ParseEngine:
         matches.append(entry)
 
     def _find_active_formatting_index(self, name: str) -> int | None:
+        segments = self._active_formatting_entries
+        if segments and name not in segments[-1].live_names:
+            return None
         active = self._active_formatting
         for idx in range(len(active) - 1, -1, -1):
             entry = active[idx]
             if entry is _ACTIVE_FORMATTING_MARKER:
-                break
+                break  # pragma: no cover - live-name guard implies a match before the marker
             if entry.active and entry.name == name:
                 return idx
         return None
@@ -5440,6 +5449,12 @@ class ParseEngine:
         """
         entry.active = False
         entries = entry.segment
+        live = entries.live_names
+        remaining = live.get(entry.name, 0) - 1
+        if remaining > 0:
+            live[entry.name] = remaining
+        else:
+            live.pop(entry.name, None)
         if entries.pending is entry:
             entries.pending = None
         else:
@@ -5669,6 +5684,8 @@ class ParseEngine:
             ):  # pragma: no branch - opposite edge requires invalid parser state
                 bookmark = len(self._active_formatting)  # pragma: no cover - unreachable after parser-state guards
             self._active_formatting.insert(bookmark, replacement)
+            live = entries.live_names
+            live[entry.name] = live.get(entry.name, 0) + 1
             self._materialize_pending_active_formatting_entry()
             self._index_active_formatting_entry(entries, replacement)
 

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -1820,23 +1820,22 @@ class ParseEngine:
 
     def _open_parser_only_template_index(self) -> int | None:
         stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):
-            node = stack[idx]
-            if node.name == "template" and node.namespace == _PARSER_ONLY_NAMESPACE:
-                return idx
+        if not stack._indexed:
+            for index in range(len(stack) - 1, 0, -1):
+                node = stack[index]
+                if node.name == "template" and node.namespace == _PARSER_ONLY_NAMESPACE:
+                    return index
+            return None
+        positions = stack._other_positions.get("template")
+        if positions:
+            for index in reversed(positions):
+                if stack[index].namespace == _PARSER_ONLY_NAMESPACE:
+                    return index
         return None
 
     def _open_template_index(self) -> int | None:
-        stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):
-            node = stack[idx]
-            if node.name != "template":
-                continue
-            if node.namespace == _PARSER_ONLY_NAMESPACE or (
-                type(node) is Template and node.namespace in {None, "html"}
-            ):
-                return idx
-        return None
+        index = self._stack.last_template_boundary_index()
+        return index if index > 0 else None
 
     def _current_template_mode(self) -> str | None:
         modes = self._template_modes
@@ -5180,6 +5179,8 @@ class ParseEngine:
         children = table_parent.children if table_parent is not None else None
         if table_parent is None or children is None:  # pragma: no branch - opposite edge requires invalid parser state
             return None  # pragma: no cover - unreachable after parser-state guards
+        if children and children[-1] is table:
+            return table_parent, len(children) - 1
         try:
             return table_parent, children.index(table)
         except ValueError:  # pragma: no cover - unreachable after parser-state guards

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -7,7 +7,7 @@ engine without tokenizer or treebuilder handoffs.
 from __future__ import annotations
 
 import re
-from bisect import bisect_right
+from bisect import bisect_left, bisect_right
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, SupportsIndex, cast
 
@@ -742,6 +742,7 @@ class _CountingStack(list[Node]):
         "_html_positions",
         "_indexed",
         "_name_counts",
+        "_node_positions",
         "_other_positions",
         "_p_count",
     )
@@ -764,15 +765,18 @@ class _CountingStack(list[Node]):
     def _build_position_index(self) -> None:
         html: dict[str, list[int]] = {}
         other: dict[str, list[int]] = {}
+        node_positions: dict[Node, int] = {}
         foreign_boundaries: list[int] = []
         for index, item in enumerate(self):
             positions = html if item.namespace in {None, "html"} else other
             positions.setdefault(item.name, []).append(index)
+            node_positions[item] = index
             if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and (self._is_foreign_boundary(item)):
                 foreign_boundaries.append(index)
         self._html_positions = html
         self._other_positions = other
         self._foreign_boundaries = foreign_boundaries
+        self._node_positions = node_positions
         self._indexed = True
 
     @staticmethod
@@ -869,6 +873,7 @@ class _CountingStack(list[Node]):
     def _note_top_position(self, item: Node, index: int) -> None:
         positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
         positions.setdefault(item.name, []).append(index)
+        self._node_positions[item] = index
         if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
             self._foreign_boundaries.append(index)
 
@@ -878,8 +883,44 @@ class _CountingStack(list[Node]):
         bucket.pop()
         if not bucket:
             del positions[item.name]
+        self._node_positions.pop(item, None)
         if self._foreign_boundaries and self._foreign_boundaries[-1] == index:
             self._foreign_boundaries.pop()
+
+    def _discard_position(self, item: Node, index: int) -> None:
+        positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
+        bucket = positions[item.name]
+        del bucket[bisect_left(bucket, index)]
+        if not bucket:
+            del positions[item.name]
+        self._node_positions.pop(item, None)
+        if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
+            del self._foreign_boundaries[bisect_left(self._foreign_boundaries, index)]
+
+    def index_of_node(self, item: Node) -> int | None:
+        if not self._indexed:
+            try:
+                return list.index(self, item)
+            except ValueError:
+                return None
+        return self._node_positions.get(item)
+
+    def __contains__(self, item: object) -> bool:
+        if not self._indexed:
+            return list.__contains__(self, item)
+        return item in self._node_positions
+
+    def _renumber_from(self, first_moved: int, delta: int) -> None:
+        for position in range(first_moved, len(self)):
+            item = self[position]
+            old_position = position - delta
+            positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
+            bucket = positions[item.name]
+            bucket[bisect_left(bucket, old_position)] = position
+            self._node_positions[item] = position
+            if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
+                boundaries = self._foreign_boundaries
+                boundaries[bisect_left(boundaries, old_position)] = position
 
     def _collect_name_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
@@ -913,6 +954,10 @@ class _CountingStack(list[Node]):
             self._build_position_index()
 
     def insert(self, index: SupportsIndex, item: Node) -> None:  # type: ignore[override]
+        length = len(self)
+        was_indexed = self._indexed
+        raw_index = index.__index__()
+        normalized_index = max(0, min(raw_index if raw_index >= 0 else length + raw_index, length))
         list.insert(self, index, item)
         name = item.name
         if name == "p":
@@ -922,8 +967,15 @@ class _CountingStack(list[Node]):
             counts[name] = counts.get(name, 0) + 1
         elif len(self) >= _STACK_COUNT_THRESHOLD:
             self._name_counts = self._collect_name_counts()
-        if self._indexed:
-            self._build_position_index()
+        if was_indexed:
+            if normalized_index == length:
+                self._note_top_position(item, normalized_index)
+            else:
+                self._renumber_from(normalized_index + 1, 1)
+                positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
+                bucket = positions.setdefault(item.name, [])
+                bucket.insert(bisect_left(bucket, normalized_index), normalized_index)
+                self._node_positions[item] = normalized_index
 
     def __setitem__(self, key: SupportsIndex, item: Node) -> None:  # type: ignore[override]
         previous_name = self[key].name
@@ -957,11 +1009,15 @@ class _CountingStack(list[Node]):
             if normalized_index == len(self):
                 self._forget_top_position(item, normalized_index)
             else:
-                self._build_position_index()
+                self._discard_position(item, normalized_index)
+                self._renumber_from(normalized_index, -1)
         return item
 
     def remove(self, item: Node) -> None:  # type: ignore[override]
-        list.remove(self, item)
+        index = self.index_of_node(item)
+        if index is None:
+            raise ValueError("_CountingStack.remove(x): x not on the stack")
+        list.__delitem__(self, index)
         name = item.name
         if name == "p":
             self._p_count -= 1
@@ -969,15 +1025,23 @@ class _CountingStack(list[Node]):
         if counts is not None:
             counts[name] -= 1
         if self._indexed:
-            self._build_position_index()
+            if index == len(self):
+                self._forget_top_position(item, index)
+            else:
+                self._discard_position(item, index)
+                self._renumber_from(index, -1)
 
     def __delitem__(self, key: SupportsIndex | slice) -> None:
+        normalized_index: int | None = None
         if isinstance(key, slice):
             start, stop, step = key.indices(len(self))
             if self._indexed and step == 1 and stop >= len(self):
                 while len(self) > start:
                     self.pop()
                 return
+        else:
+            raw_index = key.__index__()
+            normalized_index = raw_index if raw_index >= 0 else len(self) + raw_index
         removed = self[key] if isinstance(key, slice) else [self[key]]
         list.__delitem__(self, key)
         p_count = self._p_count
@@ -990,7 +1054,15 @@ class _CountingStack(list[Node]):
                 counts[name] -= 1
         self._p_count = p_count
         if self._indexed:
-            self._build_position_index()
+            if normalized_index is None:
+                self._build_position_index()
+            else:
+                item = removed[0]
+                if normalized_index == len(self):
+                    self._forget_top_position(item, normalized_index)
+                else:
+                    self._discard_position(item, normalized_index)
+                    self._renumber_from(normalized_index, -1)
 
 
 class ParseEngine:
@@ -5487,12 +5559,10 @@ class ParseEngine:
                 return
 
     def _remove_last_open_element_by_name(self, name: str) -> None:
-        stack = self._stack
-        for idx in range(len(stack) - 1, 0, -1):
-            if getattr(stack[idx], "name", None) == name:
-                self._mark_active_formatting_dirty()
-                del stack[idx]
-                return
+        index = self._find_open_index(name)
+        if index is not None:
+            self._mark_active_formatting_dirty()
+            del self._stack[index]
 
     def _reconstruct_active_formatting(self) -> None:
         active = self._active_formatting
@@ -5571,9 +5641,8 @@ class ParseEngine:
                 stack.pop()
                 self._retire_active_formatting_entry(entry)
                 return
-            try:
-                formatting_stack_index = stack.index(formatting_element)
-            except ValueError:
+            formatting_stack_index = stack.index_of_node(formatting_element)
+            if formatting_stack_index is None:
                 self._retire_active_formatting_entry(entry)
                 self._refresh_active_formatting_dirty()
                 return
@@ -5694,7 +5763,9 @@ class ParseEngine:
                 stack.remove(formatting_element)
             except ValueError:  # pragma: no cover - unreachable after parser-state guards
                 pass  # pragma: no cover - unreachable after parser-state guards
-            furthest_stack_index = stack.index(furthest_block)
+            furthest_stack_index = stack.index_of_node(furthest_block)
+            if furthest_stack_index is None:  # pragma: no cover - furthest block remains open
+                return
             stack.insert(furthest_stack_index + 1, new_formatting_element)
             self._refresh_active_formatting_dirty()
 

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -846,6 +846,7 @@ class ParseEngine:
         "_after_document_mode",
         "_after_head",
         "_allowed_tags",
+        "_annotation_xml_integration",
         "_body",
         "_body_explicit",
         "_body_mode_seen",
@@ -986,6 +987,7 @@ class ParseEngine:
         self._quirks_mode = "no-quirks" if fragment else None
         self._body_explicit = False
         self._body_mode_seen = False
+        self._annotation_xml_integration: dict[Node, bool] = {}
         self._doc_html_index = -1
         self._html_anchor_index: tuple[Node | None, int] = (None, -1)
         self._close_tag_scan: dict[str, tuple[int, int]] = {}
@@ -4046,8 +4048,12 @@ class ParseEngine:
 
     def _is_html_integration_point(self, node: Node) -> bool:
         if node.namespace == "math" and node.name == "annotation-xml":
-            encoding = self._node_attr_value(node, "encoding")
-            return encoding is not None and encoding.lower() in {"application/xhtml+xml", "text/html"}
+            cached = self._annotation_xml_integration.get(node)
+            if cached is None:
+                encoding = self._node_attr_value(node, "encoding")
+                cached = encoding is not None and encoding.lower() in {"application/xhtml+xml", "text/html"}
+                self._annotation_xml_integration[node] = cached
+            return cached
         return (node.namespace, node.name) in HTML_INTEGRATION_POINT_SET
 
     def _is_mathml_text_integration_point(self, node: Node) -> bool:

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -5609,36 +5609,60 @@ class ParseEngine:
                     self._unwrap_node(node)
             nodes.clear()
             return
-        index = len(nodes) - 1
-        while index >= 0:
-            node = nodes[index]
+        marked = set(nodes)
+        holders: dict[Node, Element | None] = {}
+        nesting: set[Node] = set()
+        for node in nodes:
             parent = node.parent
             if parent is None:
-                index -= 1
                 continue
-            first = index - 1
-            while first >= 0 and nodes[first].parent is parent:
-                first -= 1
-            if first == index - 1:
-                self._unwrap_node(node)
-                index = first
+            if parent in marked:
+                nesting.add(parent)
                 continue
-            marked = set(nodes[first + 1 : index + 1])
+            holders[parent] = None if parent in holders else node
+        for parent, only_child in holders.items():
             children: list[Any] = parent.children  # type: ignore[assignment]
+            if only_child is not None:
+                position = children.index(only_child)
+                children[position : position + 1] = self._expanded_children(parent, only_child, marked, nesting)
+                continue
             projected: list[Node | Text] = []
             for child in children:
-                if child not in marked:
+                if child in marked:
+                    projected.extend(self._expanded_children(parent, child, marked, nesting))
+                else:
                     projected.append(child)
-                    continue
-                moved = child.children
-                child.children = []
-                for grandchild in moved:
-                    grandchild.parent = parent
-                projected.extend(moved)
-                child.parent = None
             children[:] = projected
-            index = first
         nodes.clear()
+
+    def _expanded_children(
+        self,
+        parent: Node,
+        node: Element,
+        marked: set[Element],
+        nesting: set[Node],
+    ) -> list[Any]:
+        moved: list[Any] = node.children
+        node.children = []
+        node.parent = None
+        for grandchild in moved:
+            grandchild.parent = parent
+        if node not in nesting:
+            return moved
+        expanded: list[Any] = []
+        pending = moved[::-1]
+        while pending:
+            child = pending.pop()
+            if child not in marked:
+                expanded.append(child)
+                continue
+            grandchildren = child.children
+            child.children = []
+            child.parent = None
+            for grandchild in grandchildren:
+                grandchild.parent = parent
+            pending.extend(reversed(grandchildren))
+        return expanded
 
     def _drop_recorded_nodes(self) -> None:
         nodes = self._nodes_to_drop

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -5833,19 +5833,27 @@ class ParseEngine:
                 pending.extend(reversed(children))
 
     def _project_select_selectedcontent(self, select: Element) -> None:
-        markers: list[Element] = []
+        markers: list[tuple[Element, int]] = []
+        option_spans: dict[Element, list[int]] = {}
         selected_option: Element | None = None
         first_option: Element | None = None
         is_multiple = "multiple" in select.attrs
-        pending: list[tuple[Node, bool, bool]] = [(select, False, False)]
+        pending: list[tuple[Node, bool, bool, bool]] = [(select, False, False, False)]
+        position = 0
         while pending:
-            node, in_disabled_optgroup, in_datalist = pending.pop()
+            node, in_disabled_optgroup, in_datalist, leaving = pending.pop()
+            if leaving:
+                option_spans[node][1] = position  # type: ignore[index]
+                continue
+            position += 1
             attrs = getattr(node, "attrs", None)
             name = node.name
             if node is not select and type(node) is Element:
                 if name == "selectedcontent":
-                    markers.append(node)
+                    markers.append((node, position))
                 if name == "option" and not in_datalist:
+                    option_spans[node] = [position, position]
+                    pending.append((node, in_disabled_optgroup, in_datalist, True))
                     if (
                         first_option is None
                         and not in_disabled_optgroup
@@ -5864,12 +5872,15 @@ class ParseEngine:
                     name == "optgroup" and attrs is not None and "disabled" in attrs
                 )
                 child_in_datalist = in_datalist or name == "datalist"
-                pending.extend((child, child_disabled_optgroup, child_in_datalist) for child in reversed(children))
+                pending.extend(
+                    (child, child_disabled_optgroup, child_in_datalist, False) for child in reversed(children)
+                )
         option = selected_option or first_option
         if not markers:  # pragma: no branch - opposite edge requires invalid parser state
             return  # pragma: no cover - unreachable after parser-state guards
-        for marker in markers:
-            if option is not None and self._is_descendant_of(marker, option):
+        span = option_spans[option] if option is not None else None
+        for marker, marker_position in markers:
+            if span is not None and span[0] < marker_position <= span[1]:
                 continue
             children = marker.children
             if children:
@@ -5880,14 +5891,6 @@ class ParseEngine:
                 for child in option.children or ():
                     clone = child.clone_node(deep=True)
                     self._append(marker, clone)
-
-    def _is_descendant_of(self, node: Node, ancestor: Node) -> bool:
-        parent = node.parent
-        while parent is not None:
-            if parent is ancestor:
-                return True
-            parent = parent.parent
-        return False
 
     def _unwrap_node(self, node: Element) -> None:
         parent = node.parent

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -849,7 +849,9 @@ class ParseEngine:
         "_body",
         "_body_explicit",
         "_body_mode_seen",
+        "_close_tag_scan",
         "_doc",
+        "_doc_html_index",
         "_drop_comments",
         "_drop_content_tags",
         "_drop_doctype",
@@ -875,6 +877,7 @@ class ParseEngine:
         "_head",
         "_head_reentry",
         "_html",
+        "_html_anchor_index",
         "_html_input",
         "_iframe_srcdoc",
         "_ignore_lf",
@@ -983,6 +986,9 @@ class ParseEngine:
         self._quirks_mode = "no-quirks" if fragment else None
         self._body_explicit = False
         self._body_mode_seen = False
+        self._doc_html_index = -1
+        self._html_anchor_index: tuple[Node | None, int] = (None, -1)
+        self._close_tag_scan: dict[str, tuple[int, int]] = {}
         self._html: Element | None = None
         self._head: Element | None = None
         self._body: Element | DocumentFragment
@@ -1423,10 +1429,31 @@ class ParseEngine:
             return f"{target} {data}"
         return f"{target} "
 
+    def _insert_before_document_root(self, node: Node) -> None:
+        children: list[Any] = self._doc.children  # type: ignore[assignment]
+        insert_at = self._doc_html_index
+        if not (0 <= insert_at < len(children) and children[insert_at].name == "html"):
+            insert_at = next((index for index, child in enumerate(children) if child.name == "html"), len(children))
+        found_root = insert_at < len(children)
+        children.insert(insert_at, node)
+        node.parent = self._doc
+        self._doc_html_index = insert_at + 1 if found_root else -1
+
+    def _last_close_tag_start(self, marker: str, source_pos: int) -> int:
+        scanned_to, best = self._close_tag_scan.get(marker, (0, -1))
+        if source_pos <= scanned_to:  # pragma: no cover - misc nodes arrive in source order
+            return _scanner.ascii_rfind(self._html_input, marker, 0, source_pos)
+        window_start = max(0, scanned_to - len(marker) + 1)
+        found = _scanner.ascii_rfind(self._html_input, marker, window_start, source_pos)
+        if found != -1:
+            best = found
+        self._close_tag_scan[marker] = (source_pos, best)
+        return best
+
     def _append_misc_node(self, node: Node, source_pos: int | None = None) -> None:
         if self._after_document_mode and source_pos is not None:
             marker = "</html" if self._after_document_mode == _AFTER_HTML else "</body"
-            close_start = _scanner.ascii_rfind(self._html_input, marker, 0, source_pos)
+            close_start = self._last_close_tag_start(marker, source_pos)
             close_end = self._html_input.find(">", close_start, source_pos) if close_start != -1 else -1
             trailing = self._html_input[close_end + 1 : source_pos] if close_end != -1 else ""
             if trailing and "<" not in trailing and trailing.strip(_SPACE):
@@ -1463,12 +1490,7 @@ class ParseEngine:
                 and self._current_parent() is self._body
             )
         ):
-            children: list[Any] = self._doc.children  # type: ignore[assignment]
-            insert_at = 0
-            while insert_at < len(children) and children[insert_at].name != "html":
-                insert_at += 1
-            children.insert(insert_at, node)
-            node.parent = self._doc
+            self._insert_before_document_root(node)
             return
         if (
             not self._fragment
@@ -1480,12 +1502,21 @@ class ParseEngine:
         ):
             children = self._html.children
             anchor = self._body if self._after_head or self._explicit_head else self._head
-            try:
-                insert_at = children.index(anchor)
-            except ValueError:  # pragma: no cover - shell anchor is owned by html
-                insert_at = len(children)
+            cached_anchor, cached_index = self._html_anchor_index
+            if cached_anchor is anchor and 0 <= cached_index < len(children) and children[cached_index] is anchor:
+                insert_at = cached_index
+                found = True
+            else:
+                try:
+                    insert_at = children.index(anchor)
+                except ValueError:  # pragma: no cover - shell anchor is owned by html
+                    insert_at = len(children)
+                    found = False
+                else:
+                    found = True
             children.insert(insert_at, node)
             node.parent = self._html
+            self._html_anchor_index = (anchor, insert_at + 1) if found else (None, -1)
             return
         self._append(self._current_parent(), node)
 

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -836,6 +836,14 @@ class _CountingStack(list[Node]):
                 best = max(best, positions[-1])
         return best
 
+    def last_html_index(self) -> int:
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                if self[index].namespace in {None, "html"}:
+                    return index
+            return -1
+        return max((positions[-1] for positions in self._html_positions.values()), default=-1)
+
     def last_foreign_boundary_index(self) -> int:
         if not self._indexed:
             for index in range(len(self) - 1, 0, -1):
@@ -1317,28 +1325,32 @@ class ParseEngine:
         if name in {"br", "p"}:
             return False
 
-        crossed_integration_point = False
-        for idx in range(len(stack) - 1, 0, -1):
-            node = stack[idx]
-            if self._node_matches_end_name(node, name):
-                if node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE} and crossed_integration_point:
-                    return True
-                if self._fragment_context_node is not None and node is self._fragment_context_node:
-                    return True
-                if node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE}:
-                    # The foreign-content walk reached a matching HTML element
-                    # (§13.2.6.5 steps 6-7): hand the token to the HTML end-tag
-                    # rules, which may splice a form or run adoption, rather than
-                    # popping the foreign elements sitting above it.
-                    return False
-                if self._track_tag_spans:
-                    self._set_end_span(node, name, tag_start, tag_end)
-                del stack[idx:]
-                return True
-            if self._is_html_integration_point(node) or self._is_mathml_text_integration_point(node):
-                crossed_integration_point = True
-            if node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE}:
-                return False
+        target_index = stack.last_index_of(name)
+        adjusted_name = SVG_TAG_NAME_ADJUSTMENTS.get(name, name)
+        if adjusted_name != name:
+            adjusted_index = stack.last_index_of(adjusted_name)
+            if adjusted_index is not None and (target_index is None or adjusted_index > target_index):
+                target_index = adjusted_index
+
+        html_index = stack.last_html_index()
+        if target_index is None or target_index < html_index:
+            return html_index < 0
+
+        node = stack[target_index]
+        node_is_html = node.namespace in {None, "html", _PARSER_ONLY_NAMESPACE}
+        if node_is_html and stack.last_foreign_boundary_index() > target_index:
+            return True
+        if self._fragment_context_node is not None and node is self._fragment_context_node:
+            return True
+        if node_is_html:
+            # The foreign-content walk reached a matching HTML element
+            # (§13.2.6.5 steps 6-7): hand the token to the HTML end-tag
+            # rules, which may splice a form or run adoption, rather than
+            # popping the foreign elements sitting above it.
+            return False
+        if self._track_tag_spans:
+            self._set_end_span(node, name, tag_start, tag_end)
+        del stack[target_index:]
         return True
 
     def _emit_error(

--- a/src/justhtml/parser/stream.py
+++ b/src/justhtml/parser/stream.py
@@ -39,7 +39,7 @@ _TAG_END_NAME_STOP = _scanner.TAG_END_NAME_STOP
 
 
 class _StreamNode:
-    __slots__ = ("attrs", "name", "namespace")
+    __slots__ = ("attrs", "html_integration", "name", "namespace")
 
     attrs: dict[str, str | None]
     name: str
@@ -49,6 +49,20 @@ class _StreamNode:
         self.attrs = attrs or {}
         self.name = name
         self.namespace = namespace
+        if namespace == "math" and name == "annotation-xml":
+            encoding = self._attribute_value("encoding")
+            self.html_integration = encoding is not None and encoding.lower() in {
+                "application/xhtml+xml",
+                "text/html",
+            }
+        else:
+            self.html_integration = (namespace, name) in HTML_INTEGRATION_POINT_SET
+
+    def _attribute_value(self, name: str) -> str | None:
+        for attr_name, attr_value in self.attrs.items():
+            if attr_name.lower() == name:
+                return attr_value or ""
+        return None
 
 
 class _StreamScanner:
@@ -405,18 +419,8 @@ class _StreamScanner:
                 return True
         return False
 
-    def _node_attribute_value(self, node: _StreamNode, name: str) -> str | None:
-        target = name.lower()
-        for attr_name, attr_value in node.attrs.items():
-            if attr_name.lower() == target:
-                return attr_value or ""
-        return None
-
     def _is_html_integration_point(self, node: _StreamNode) -> bool:
-        if node.namespace == "math" and node.name == "annotation-xml":
-            encoding = self._node_attribute_value(node, "encoding")
-            return encoding is not None and encoding.lower() in {"application/xhtml+xml", "text/html"}
-        return (node.namespace, node.name) in HTML_INTEGRATION_POINT_SET
+        return node.html_integration
 
     def _is_mathml_text_integration_point(self, node: _StreamNode) -> bool:
         return (node.namespace, node.name) in MATHML_TEXT_INTEGRATION_POINT_SET

--- a/src/justhtml/parser/stream.py
+++ b/src/justhtml/parser/stream.py
@@ -66,34 +66,47 @@ class _StreamNode:
 
 
 class _StreamScanner:
-    __slots__ = ("_html", "_name_counts", "_open_elements")
+    __slots__ = ("_html", "_html_positions", "_name_positions", "_open_elements")
 
     _html: str
     _open_elements: list[_StreamNode]
-    _name_counts: dict[str, int]
+    _name_positions: dict[str, list[int]]
+    _html_positions: list[int]
 
     def __init__(self, html: str) -> None:
         self._html = html
         self._open_elements = []
-        self._name_counts = {}
+        self._name_positions = {}
+        self._html_positions = []
 
     def _push_open_element(self, node: _StreamNode) -> None:
+        index = len(self._open_elements)
         self._open_elements.append(node)
+        bucket = self._name_positions.get(node.name.lower())
+        if bucket is None:
+            self._name_positions[node.name.lower()] = [index]
+        else:
+            bucket.append(index)
+        if node.namespace in {None, "html"}:
+            self._html_positions.append(index)
+
+    def _forget_open_element(self, node: _StreamNode) -> None:
         key = node.name.lower()
-        self._name_counts[key] = self._name_counts.get(key, 0) + 1
+        bucket = self._name_positions[key]
+        bucket.pop()
+        if not bucket:
+            del self._name_positions[key]
+        if node.namespace in {None, "html"}:
+            self._html_positions.pop()
 
     def _pop_open_element(self) -> _StreamNode:
         node = self._open_elements.pop()
-        key = node.name.lower()
-        self._name_counts[key] -= 1
+        self._forget_open_element(node)
         return node
 
     def _truncate_open_elements(self, index: int) -> None:
-        removed = self._open_elements[index:]
-        del self._open_elements[index:]
-        for node in removed:
-            key = node.name.lower()
-            self._name_counts[key] -= 1
+        while len(self._open_elements) > index:
+            self._forget_open_element(self._open_elements.pop())
 
     def scan(self) -> Generator[StreamEvent, None, None]:
         html = self._html
@@ -475,21 +488,13 @@ class _StreamScanner:
             self._pop_foreign_context()
             return
 
-        # Skip the scan entirely when the name isn't open anywhere on the
-        # stack: an unmatched end tag deep inside foreign content (svg/math)
-        # would otherwise scan the whole stack on every single end tag,
-        # making a run of unmatched end tags quadratic overall.
-        if self._name_counts.get(name_lower, 0) > 0:
-            for index in range(len(self._open_elements) - 1, -1, -1):  # pragma: no branch
-                node = self._open_elements[index]
-                if node.name.lower() == name_lower:
-                    self._truncate_open_elements(index)
-                    return
-                if node.namespace in {None, "html"}:
-                    break
-            # Unreachable: count_of > 0 guarantees a match exists at some index
-            # in this exact range, so the loop above always returns or breaks
-            # before exhausting it.
+        bucket = self._name_positions.get(name_lower)
+        if bucket is not None:
+            target = bucket[-1]
+            html_positions = self._html_positions
+            if target >= (html_positions[-1] if html_positions else -1):
+                self._truncate_open_elements(target)
+                return
 
         self._pop_open_element()
 

--- a/src/justhtml/serializer/html.py
+++ b/src/justhtml/serializer/html.py
@@ -552,17 +552,22 @@ def _is_whitespace_text_node(node: Any) -> bool:
     return node.name == "#text" and (node.data or "").strip() == ""
 
 
-def _is_blocky_element(node: Any) -> bool:
+_NON_ELEMENT_NODE_NAMES = {"#text", "#comment", "!doctype"}
+
+
+def _is_blocky_element(node: Any, descendants: dict[Any, bool] | None = None) -> bool:
     # Treat elements as block-ish if they are block-level *or* contain any block-level
     # descendants. This keeps pretty-printing readable for constructs like <a><div>...</div></a>.
     try:
         name = node.name
     except AttributeError:
         return False
-    if name in {"#text", "#comment", "!doctype"}:
+    if name in _NON_ELEMENT_NODE_NAMES:
         return False
     if name in SPECIAL_ELEMENTS:
         return True
+    if descendants is not None:
+        return descendants.get(node, False)
 
     try:
         children = node.children
@@ -648,7 +653,7 @@ _LAYOUT_BLOCK_ELEMENTS = {
 _FORMAT_SEP = object()
 
 
-def _is_layout_blocky_element(node: Any) -> bool:
+def _is_layout_blocky_element(node: Any, descendants: dict[Any, bool] | None = None) -> bool:
     # Similar to _is_blocky_element(), but limited to actual layout blocks.
     # This avoids turning inline-ish "special" elements like <script> into
     # multiline pretty-print breaks in contexts like <p>.
@@ -656,10 +661,12 @@ def _is_layout_blocky_element(node: Any) -> bool:
         name = node.name
     except AttributeError:
         return False
-    if name in {"#text", "#comment", "!doctype"}:
+    if name in _NON_ELEMENT_NODE_NAMES:
         return False
     if name in _LAYOUT_BLOCK_ELEMENTS:
         return True
+    if descendants is not None:
+        return descendants.get(node, False)
 
     try:
         children = node.children
@@ -720,7 +727,7 @@ def _is_formatting_whitespace_text(data: str) -> bool:
     return len(data) > 2
 
 
-def _should_pretty_indent_children(children: list[Any]) -> bool:
+def _should_pretty_indent_children(children: list[Any], block_descendants: dict[Any, bool] | None = None) -> bool:
     for child in children:
         if child is None:
             continue
@@ -737,15 +744,15 @@ def _should_pretty_indent_children(children: list[Any]) -> bool:
         return True
     if len(element_children) == 1:
         only_child = element_children[0]
-        if _is_blocky_element(only_child):
+        if _is_blocky_element(only_child, block_descendants):
             return True
         return False
 
     # Safe indentation rule: only insert inter-element whitespace when we won't
     # be placing it between two adjacent inline/phrasing elements.
-    prev_is_blocky = _is_blocky_element(element_children[0])
+    prev_is_blocky = _is_blocky_element(element_children[0], block_descendants)
     for child in element_children[1:]:
-        current_is_blocky = _is_blocky_element(child)
+        current_is_blocky = _is_blocky_element(child, block_descendants)
         if not prev_is_blocky and not current_is_blocky:
             return False
         prev_is_blocky = current_is_blocky
@@ -754,6 +761,32 @@ def _should_pretty_indent_children(children: list[Any]) -> bool:
 
 _HTML_FRAGMENT = str | tuple["_HTML_FRAGMENT", ...]
 _MAX_PRETTY_INDENT_DEPTH = 64
+
+
+def _classify_block_descendants(root: Any) -> tuple[dict[Any, bool], dict[Any, bool]]:
+    """Classify every subtree once for the two pretty-print block sets."""
+    special: dict[Any, bool] = {}
+    layout: dict[Any, bool] = {}
+    stack: list[tuple[Any, bool]] = [(root, False)]
+    while stack:
+        node, expanded = stack.pop()
+        children = getattr(node, "children", None)
+        if not children:
+            continue
+        if not expanded:
+            stack.append((node, True))
+            for child in children:
+                if child is not None and child.name not in _NON_ELEMENT_NODE_NAMES:
+                    stack.append((child, False))
+            continue
+        special[node] = any(
+            child is not None and (child.name in SPECIAL_ELEMENTS or special.get(child, False)) for child in children
+        )
+        layout[node] = any(
+            child is not None and (child.name in _LAYOUT_BLOCK_ELEMENTS or layout.get(child, False))
+            for child in children
+        )
+    return special, layout
 
 
 def _pretty_indent(depth: int, indent_size: int) -> str:
@@ -797,6 +830,7 @@ def _html_fragment_to_string(fragment: _HTML_FRAGMENT) -> str:
 
 def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: bool) -> str:
     """Helper to convert a node to HTML using an explicit stack."""
+    block_descendants, layout_descendants = _classify_block_descendants(node)
     tasks: list[Any] = [("visit", node, indent, in_pre)]
     results: list[_HTML_FRAGMENT] = []
 
@@ -960,7 +994,8 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                             blocky_elements = [
                                 child
                                 for child in run
-                                if child.name not in {"#text", "#comment"} and _is_blocky_element(child)
+                                if child.name not in {"#text", "#comment"}
+                                and _is_blocky_element(child, block_descendants)
                             ]
                             if blocky_elements and len(run) != 1:
                                 can_apply = False
@@ -1008,14 +1043,14 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                             )
                             continue
 
-            if not _should_pretty_indent_children(children):
+            if not _should_pretty_indent_children(children, block_descendants):
                 if name in SPECIAL_ELEMENTS:
                     has_comment = any(child is not None and child.name == "#comment" for child in children)
                     if not has_comment:
                         has_blocky_child = any(
                             child is not None
                             and child.name not in {"#text", "#comment"}
-                            and _is_layout_blocky_element(child)
+                            and _is_layout_blocky_element(child, layout_descendants)
                             for child in children
                         )
                         has_non_whitespace_text = any(
@@ -1066,7 +1101,7 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                                     inline_parts.append(("lit", _escape_text(_normalize_formatting_whitespace(data))))
                                     continue
 
-                                if _is_layout_blocky_element(child):
+                                if _is_layout_blocky_element(child, layout_descendants):
                                     flush_inline_parts()
                                     idx = len(child_specs)
                                     child_specs.append((child, current_indent + 1, False))

--- a/tests/harness/scaling.py
+++ b/tests/harness/scaling.py
@@ -1,0 +1,66 @@
+# coverage: exclude file
+"""Shared timing assertion for complexity-regression tests.
+
+The guarded input shapes are quadratic when their fast path regresses, so
+doubling the input takes roughly four times as long instead of two. This helper
+keeps enough margin between those outcomes by collecting before measurement,
+disabling the collector during it, and retaining the fastest sample.
+
+Reusable operations are batched when a single call is very short. That avoids
+letting timer, scheduler, or JIT noise dominate the measurement.
+"""
+
+import gc
+import math
+from time import perf_counter
+
+SMALL_SIZE = 2_000
+LARGE_SIZE = 4_000
+MAX_GROWTH = 3.0
+SAMPLES = 5
+MIN_SAMPLE_SECONDS = 0.01
+MAX_BATCH_RUNS = 128
+
+
+def _fastest(prepare, run, size: int, *, reusable: bool) -> float:
+    payload = prepare(size)
+    run(payload)
+    gc.collect()
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        batch_runs = 1
+        if reusable:
+            start = perf_counter()
+            run(payload)
+            elapsed = perf_counter() - start
+            if elapsed < MIN_SAMPLE_SECONDS:
+                batch_runs = min(
+                    MAX_BATCH_RUNS,
+                    max(2, math.ceil(MIN_SAMPLE_SECONDS / max(elapsed, 1e-9))),
+                )
+
+        best = float("inf")
+        for _ in range(SAMPLES):
+            if not reusable:
+                payload = prepare(size)
+            start = perf_counter()
+            for _ in range(batch_runs):
+                run(payload)
+            best = min(best, (perf_counter() - start) / batch_runs)
+        return best
+    finally:
+        if was_enabled:
+            gc.enable()
+
+
+def assert_scales_linearly(prepare, run, *, label: str = "input", reusable: bool = True) -> None:
+    """Assert that doubling a prepared input keeps the operation linear."""
+    small = _fastest(prepare, run, SMALL_SIZE, reusable=reusable)
+    large = _fastest(prepare, run, LARGE_SIZE, reusable=reusable)
+    growth = large / small
+    assert growth < MAX_GROWTH, (
+        f"doubling {label} took {growth:.2f}x as long "
+        f"({SMALL_SIZE}: {small * 1000:.2f}ms, {LARGE_SIZE}: {large * 1000:.2f}ms); "
+        f"linear is ~2x and quadratic ~4x"
+    )

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -21,6 +21,7 @@ from justhtml.serializer.markdown import (
     _MarkdownBuilder,
     _to_markdown_walk,
 )
+from tests.harness.scaling import assert_scales_linearly
 
 
 class TestNode(unittest.TestCase):
@@ -1344,3 +1345,17 @@ class TestNode(unittest.TestCase):
         text = Text("hello")
         assert text.children == []
         assert not text.has_child_nodes()
+
+
+class TestDeepCloneScaling(unittest.TestCase):
+    def test_cloning_a_template_bearing_tree_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: JustHTML("<div><template></template>" * size, sanitize=False).root,
+            lambda root: root.clone_node(deep=True),
+        )
+
+    def test_cloning_a_deep_plain_tree_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: JustHTML("<div>" * size + "x", sanitize=False).root,
+            lambda root: root.clone_node(deep=True),
+        )

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -71,10 +71,16 @@ class TestSelectedContentScaling(unittest.TestCase):
     def test_deep_selectedcontent_projection_scales_linearly(self) -> None:
         assert_scales_linearly(
             lambda size: (
-                "<select><option selected>x</option>"
-                + "<div><selectedcontent></selectedcontent>" * size
-                + "</select>"
+                "<select><option selected>x</option>" + "<div><selectedcontent></selectedcontent>" * size + "</select>"
             ),
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
+
+class TestActiveFormattingScaling(unittest.TestCase):
+    def test_absent_formatting_end_tags_scale_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "".join(f"<b id={index}>" for index in range(size)) + "</i>" * size,
             lambda source: JustHTML(source, sanitize=False),
         )
 

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -51,6 +51,12 @@ class TestDocumentShellScaling(unittest.TestCase):
 
 
 class TestForeignContentScaling(unittest.TestCase):
+    def test_deep_foreign_end_tag_searches_scale_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<div><svg><foreignObject><svg>" + "<g>" * size + "</div>" * size,
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
     def test_deep_foreign_parent_membership_scales_linearly(self) -> None:
         assert_scales_linearly(
             lambda size: "<svg>" + "<g>" * size + "<div>x",

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -84,6 +84,14 @@ class TestActiveFormattingScaling(unittest.TestCase):
             lambda source: JustHTML(source, sanitize=False),
         )
 
+    def test_adoption_reparenting_scales_linearly(self) -> None:
+        shapes = (
+            lambda size: "<a><div>" * size + "x",
+            lambda size: "<b><div></b>" * size,
+        )
+        for shape in shapes:
+            assert_scales_linearly(shape, lambda source: JustHTML(source, sanitize=False))
+
 
 class TestFramesetDepth(unittest.TestCase):
     def test_deep_frameset_eligibility_does_not_recurse(self) -> None:
@@ -208,6 +216,18 @@ class TestCountingStack(unittest.TestCase):
         assert engine._find_open_index_in_current_scope("missing") is None
         engine._stack = [DocumentFragment(), Template("template", {}, namespace="html")]
         assert engine._find_open_index_in_current_scope("missing") is None
+
+        foreign = Element("foreignObject", {}, "svg")
+        mutations = _CountingStack([*nodes, foreign, Element("span", {}, "html")])
+        mutations.remove(nodes[-1])
+        assert mutations.last_foreign_boundary_index() == len(mutations) - 2
+        del mutations[-2]
+        assert mutations.last_foreign_boundary_index() == -1
+        del mutations[-1]
+        del mutations[1]
+        with self.assertRaises(ValueError):
+            mutations.remove(Element("missing", {}, "html"))
+        self.assert_counts_match(mutations)
 
     def test_append_and_insert_activate_name_tracking_at_the_threshold(self) -> None:
         shallow = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD - 1)]

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -51,6 +51,12 @@ class TestDocumentShellScaling(unittest.TestCase):
 
 
 class TestForeignContentScaling(unittest.TestCase):
+    def test_deep_foreign_parent_membership_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<svg>" + "<g>" * size + "<div>x",
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
     def test_annotation_xml_integration_checks_scale_linearly(self) -> None:
         def source(size: int) -> str:
             attrs = " ".join(f"a{index}" for index in range(size))

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -156,7 +156,71 @@ class TestOpenElementStackScaling(unittest.TestCase):
             assert_scales_linearly(shape, lambda source: JustHTML(source, sanitize=False))
 
 
+class TestTemplateLookupScaling(unittest.TestCase):
+    def test_foster_parenting_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<!doctype html><table>" + "<br>" * size + "</table>",
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
+    def test_deep_foster_template_lookups_scale_linearly(self) -> None:
+        shapes = (
+            lambda size: "<div>" * size + "<table>" + "<br>" * size + "</table>" + "</div>" * size,
+            lambda size: (
+                "<template>"
+                + "<div>" * size
+                + "<table>"
+                + "<br>" * size
+                + "</table>"
+                + "</div>" * size
+                + "</template>"
+            ),
+        )
+        for shape in shapes:
+            assert_scales_linearly(
+                shape,
+                lambda source: JustHTML(
+                    source,
+                    fragment=True,
+                    sanitize=False,
+                ),
+            )
+
+
 class TestCountingStack(unittest.TestCase):
+    def test_indexed_parser_only_template_lookup_skips_foreign_namesakes(self) -> None:
+        engine = ParseEngine("", fragment=True)
+        root = DocumentFragment()
+        foreign_template = Element("template", {}, "svg")
+        parser_template = Element("template", {}, "justhtml-parser-only")
+        engine._stack = _CountingStack(
+            [root]
+            + [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD)]
+            + [foreign_template, parser_template]
+        )
+
+        assert engine._open_parser_only_template_index() == len(engine._stack) - 1
+
+    def test_foster_parent_uses_the_trailing_table_anchor(self) -> None:
+        class NoSearchList(list):
+            def index(self, value, start=0, stop=None):
+                raise AssertionError("the trailing table anchor must not require a sibling search")
+
+        engine = ParseEngine("", fragment=True)
+        container = Element("div", {}, "html")
+        table = Element("table", {}, "html")
+        children = NoSearchList([table])
+        container.children = children
+        table.parent = container
+        engine._stack = _CountingStack([DocumentFragment(), container, table])
+
+        assert engine._foster_parent_for(table) == (container, 0)
+
+        following = Element("span", {}, "html")
+        container.children = [table, following]
+        following.parent = container
+        assert engine._foster_parent_for(table) == (container, 0)
+
     def assert_counts_match(self, stack: _CountingStack) -> None:
         expected = Counter(node.name for node in stack)
         assert stack.count_of("p") == expected["p"]

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -157,6 +157,12 @@ class TestOpenElementStackScaling(unittest.TestCase):
 
 
 class TestTemplateLookupScaling(unittest.TestCase):
+    def test_parser_only_template_cleanup_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<template>" * size + "x" + "</template>" * size,
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
     def test_foster_parenting_scales_linearly(self) -> None:
         assert_scales_linearly(
             lambda size: "<!doctype html><table>" + "<br>" * size + "</table>",

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -49,6 +49,15 @@ class TestDocumentShellScaling(unittest.TestCase):
         )
 
 
+class TestForeignContentScaling(unittest.TestCase):
+    def test_annotation_xml_integration_checks_scale_linearly(self) -> None:
+        def source(size: int) -> str:
+            attrs = " ".join(f"a{index}" for index in range(size))
+            return f"<math><annotation-xml {attrs} encoding=text/html>" + "<svg/>" * size
+
+        assert_scales_linearly(source, lambda html: JustHTML(html, sanitize=False))
+
+
 class TestCountingStack(unittest.TestCase):
     def assert_counts_match(self, stack: _CountingStack) -> None:
         expected = Counter(node.name for node in stack)

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -93,6 +93,19 @@ class TestActiveFormattingScaling(unittest.TestCase):
             assert_scales_linearly(shape, lambda source: JustHTML(source, sanitize=False))
 
 
+class TestDiagnosticScaling(unittest.TestCase):
+    def test_basic_error_collection_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<x>" * size + "</missing>" * size + "</x>" * size,
+            lambda source: JustHTML(
+                source,
+                fragment=True,
+                sanitize=False,
+                collect_errors=True,
+            ),
+        )
+
+
 class TestFramesetDepth(unittest.TestCase):
     def test_deep_frameset_eligibility_does_not_recurse(self) -> None:
         limit = sys.getrecursionlimit()
@@ -1547,6 +1560,29 @@ class TestParserEngineInternals(_ParserEngineTestCase):
 
 
 class TestParserDiagnosticModes(_ParserEngineTestCase):
+    def test_basic_error_collection_handles_repeated_duplicate_tag_names(self) -> None:
+        engine = ParseEngine("<x>" * 64 + "</x>" * 64, fragment=True, collect_errors=True)
+
+        engine._collect_basic_errors()
+
+        assert engine.errors == []
+
+    def test_basic_error_collection_handles_large_suffix_truncations(self) -> None:
+        engine = ParseEngine("<a>" + "<b>" * 64 + "</a>" + "</b>" * 64, fragment=True, collect_errors=True)
+
+        engine._collect_basic_errors()
+
+        assert [error.code for error in engine.errors] == ["unexpected-end-tag"] * 64
+
+    def test_basic_error_collection_respects_paragraph_scope_boundaries(self) -> None:
+        engine = ParseEngine("<p><object><div></p></object>", fragment=True, collect_errors=True)
+
+        engine._collect_basic_errors()
+
+        assert [(error.code, error.message) for error in engine.errors] == [
+            ("unexpected-end-tag", "Unexpected </object> end tag"),
+        ]
+
     def test_upstream_inputs_across_diagnostic_modes(self) -> None:
         config = {
             "fail_fast": False,

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -67,6 +67,18 @@ class TestSanitizerScaling(unittest.TestCase):
         )
 
 
+class TestSelectedContentScaling(unittest.TestCase):
+    def test_deep_selectedcontent_projection_scales_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: (
+                "<select><option selected>x</option>"
+                + "<div><selectedcontent></selectedcontent>" * size
+                + "</select>"
+            ),
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
+
 class TestFramesetDepth(unittest.TestCase):
     def test_deep_frameset_eligibility_does_not_recurse(self) -> None:
         limit = sys.getrecursionlimit()

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -58,6 +58,14 @@ class TestForeignContentScaling(unittest.TestCase):
         assert_scales_linearly(source, lambda html: JustHTML(html, sanitize=False))
 
 
+class TestSanitizerScaling(unittest.TestCase):
+    def test_nested_disallowed_wrappers_scale_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<section>x" * size,
+            lambda source: JustHTML(source),
+        )
+
+
 class TestCountingStack(unittest.TestCase):
     def assert_counts_match(self, stack: _CountingStack) -> None:
         expected = Counter(node.name for node in stack)

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -90,6 +90,12 @@ class TestSelectedContentScaling(unittest.TestCase):
 
 
 class TestActiveFormattingScaling(unittest.TestCase):
+    def test_detached_formatting_node_is_not_in_scope(self) -> None:
+        engine = ParseEngine("", fragment=True)
+        engine.parse()
+
+        assert not engine._has_node_in_scope(Element("b", {}, "html"), frozenset({"table"}))
+
     def test_absent_formatting_end_tags_scale_linearly(self) -> None:
         assert_scales_linearly(
             lambda size: "".join(f"<b id={index}>" for index in range(size)) + "</i>" * size,
@@ -100,6 +106,7 @@ class TestActiveFormattingScaling(unittest.TestCase):
         shapes = (
             lambda size: "<a><div>" * size + "x",
             lambda size: "<b><div></b>" * size,
+            lambda size: "<b><table>" + "<span>" * size + "</b>" * size,
         )
         for shape in shapes:
             assert_scales_linearly(shape, lambda source: JustHTML(source, sanitize=False))

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from collections import Counter
 from dataclasses import replace
@@ -64,6 +65,21 @@ class TestSanitizerScaling(unittest.TestCase):
             lambda size: "<section>x" * size,
             lambda source: JustHTML(source),
         )
+
+
+class TestFramesetDepth(unittest.TestCase):
+    def test_deep_frameset_eligibility_does_not_recurse(self) -> None:
+        limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(1_000)
+        try:
+            sources = (
+                "<div>" * 5_000 + "<frameset>",
+                "<svg>" * 5_000 + "</svg>" * 5_000 + "<frameset>",
+            )
+            for source in sources:
+                JustHTML(source, sanitize=False)
+        finally:
+            sys.setrecursionlimit(limit)
 
 
 class TestCountingStack(unittest.TestCase):

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from justhtml import JustHTML
-from justhtml.dom import DocumentFragment, Element, Text
+from justhtml.dom import DocumentFragment, Element, Template, Text
 from justhtml.parser.context import FragmentContext
 from justhtml.parser.engine import (
     _AFTER_BODY,
@@ -82,6 +82,22 @@ class TestFramesetDepth(unittest.TestCase):
             sys.setrecursionlimit(limit)
 
 
+class TestOpenElementStackScaling(unittest.TestCase):
+    def test_deep_ordinary_elements_scale_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<span>" * size + "x",
+            lambda source: JustHTML(source, sanitize=False),
+        )
+
+    def test_out_of_scope_end_tags_scale_linearly(self) -> None:
+        shapes = (
+            lambda size: "<x><div>" + "<span>" * size + "</x>" * size,
+            lambda size: "<p><button>" + "<b>" * size + "</p>" * size,
+        )
+        for shape in shapes:
+            assert_scales_linearly(shape, lambda source: JustHTML(source, sanitize=False))
+
+
 class TestCountingStack(unittest.TestCase):
     def assert_counts_match(self, stack: _CountingStack) -> None:
         expected = Counter(node.name for node in stack)
@@ -136,6 +152,44 @@ class TestCountingStack(unittest.TestCase):
         assert stack._name_counts is not None
         stack.append(Element("span", {}, "html"))
         self.assert_counts_match(stack)
+
+    def test_deep_stack_position_index_handles_boundaries_and_middle_mutations(self) -> None:
+        nodes = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD)]
+        initially_foreign = _CountingStack([*nodes[:-1], Element("foreignObject", {}, "svg")])
+        assert initially_foreign.last_foreign_boundary_index() == len(initially_foreign) - 1
+        stack = _CountingStack(nodes)
+        plain_annotation = Element("annotation-xml", {}, "math")
+        html_annotation = Element("annotation-xml", {"other": "x", "ENCODING": "text/html"}, "math")
+        parser_template = Element("template", {}, "justhtml-parser-only")
+        html_template = Template("template", {}, namespace="html")
+
+        stack.append(plain_annotation)
+        assert stack.last_foreign_boundary_index() == -1
+        stack.append(html_annotation)
+        assert stack.last_foreign_boundary_index() == len(stack) - 1
+        stack.append(parser_template)
+        stack.append(html_template)
+        assert stack.last_html_index_of("template", parser_only=True) == len(stack) - 1
+        assert stack.last_template_boundary_index() == len(stack) - 1
+
+        stack.pop()
+        assert stack.last_template_boundary_index() == len(stack) - 1
+        stack.pop()
+        stack.pop()
+        assert stack.last_foreign_boundary_index() == -1
+        stack.pop(1)
+        del stack[1:3]
+        self.assert_counts_match(stack)
+
+        engine = ParseEngine("", fragment=True)
+        engine._stack = [DocumentFragment(), Element("div", {}, "html")]
+        assert engine._find_open_index("div") == 1
+        assert engine._find_open_index("missing") is None
+        assert engine._find_open_html_index("div") == 1
+        assert engine._find_open_index_in_current_scope("div") == 1
+        assert engine._find_open_index_in_current_scope("missing") is None
+        engine._stack = [DocumentFragment(), Template("template", {}, namespace="html")]
+        assert engine._find_open_index_in_current_scope("missing") is None
 
     def test_append_and_insert_activate_name_tracking_at_the_threshold(self) -> None:
         shallow = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD - 1)]

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -160,7 +160,7 @@ class TestTemplateLookupScaling(unittest.TestCase):
     def test_parser_only_template_cleanup_scales_linearly(self) -> None:
         assert_scales_linearly(
             lambda size: "<template>" * size + "x" + "</template>" * size,
-            lambda source: JustHTML(source, sanitize=False),
+            JustHTML,
         )
 
     def test_foster_parenting_scales_linearly(self) -> None:

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -22,6 +22,7 @@ from justhtml.parser.engine import (
 from justhtml.parser.options import ParserOptions
 from justhtml.sanitizer import DEFAULT_DOCUMENT_POLICY, DEFAULT_POLICY, SanitizationPolicy, UrlPolicy, UrlRule
 from justhtml.serializer import to_test_format
+from tests.harness.scaling import assert_scales_linearly
 from tests.harness.tree import TestRunner
 
 
@@ -30,6 +31,22 @@ class _ParserEngineTestCase(unittest.TestCase):
         document = JustHTML(html, **kwargs)
         assert document.to_html(pretty=False) == expected
         return document
+
+
+class TestDocumentShellScaling(unittest.TestCase):
+    def test_comment_placement_scales_linearly(self) -> None:
+        prefixes = ("<!doctype html>", "<html>", "<head></head>")
+        for prefix in prefixes:
+            assert_scales_linearly(
+                lambda size, prefix=prefix: prefix + "<!---->" * size,
+                lambda source: JustHTML(source, sanitize=False),
+            )
+
+    def test_trailing_comments_scale_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<!doctype html><html><head></head><body></body></html>" + "<!---->" * size,
+            lambda source: JustHTML(source, sanitize=False),
+        )
 
 
 class TestCountingStack(unittest.TestCase):

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -24,6 +24,7 @@ from justhtml.serializer import (
     to_html,
     to_test_format,
 )
+from tests.harness.scaling import assert_scales_linearly
 
 
 def JustHTML(*args, **kwargs):  # noqa: N802
@@ -522,6 +523,9 @@ class TestSerialize(unittest.TestCase):
         assert _is_blocky_element(Text("x")) is False
         assert _is_blocky_element(Comment(data="c")) is False
         assert _is_blocky_element(Node("!doctype")) is False
+        wrapper = Node("span")
+        wrapper.append_child(Text("x"))
+        assert _is_blocky_element(wrapper) is False
 
     def test_is_blocky_element_returns_false_for_objects_without_children(self):
         class _NameOnly:
@@ -534,6 +538,10 @@ class TestSerialize(unittest.TestCase):
 
     def test_is_layout_blocky_element_returns_false_for_comment_node(self):
         assert _is_layout_blocky_element(Comment(data="c")) is False
+        assert _is_layout_blocky_element(Node("span")) is False
+        wrapper = Node("span")
+        wrapper.append_child(Text("x"))
+        assert _is_layout_blocky_element(wrapper) is False
 
     def test_is_layout_blocky_element_true_for_layout_blocks_and_descendants(self):
         assert _is_layout_blocky_element(Node("div")) is True
@@ -1420,6 +1428,18 @@ class TestSerialize(unittest.TestCase):
 
     def test_escape_url_value_empty(self):
         assert _JustHTML.escape_url_value("") == ""
+
+    def test_pretty_nested_inline_markup_scales_linearly(self):
+        assert_scales_linearly(
+            lambda size: _JustHTML("<span>" * size + "x", sanitize=False).root,
+            lambda root: root.to_html(pretty=True),
+        )
+
+    def test_pretty_nested_inline_around_block_scales_linearly(self):
+        assert_scales_linearly(
+            lambda size: _JustHTML("<span>" * size + "<div>x", sanitize=False).root,
+            lambda root: root.to_html(pretty=True),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -10,6 +10,7 @@ from justhtml.parser.scanner import (
     find_script_end_tag,
 )
 from justhtml.parser.stream import _StreamScanner
+from tests.harness.scaling import assert_scales_linearly
 
 
 class TestStream(unittest.TestCase):
@@ -523,3 +524,12 @@ class TestStream(unittest.TestCase):
             ("text", "x"),
             ("end", "svg"),
         ]
+
+
+class TestStreamScaling(unittest.TestCase):
+    def test_annotation_xml_integration_checks_scale_linearly(self) -> None:
+        def source(size: int) -> str:
+            attrs = " ".join(f"a{index}" for index in range(size))
+            return f"<math><annotation-xml {attrs} encoding=text/html>" + "<svg/>" * size
+
+        assert_scales_linearly(source, lambda html: list(stream(html)))

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -533,3 +533,9 @@ class TestStreamScaling(unittest.TestCase):
             return f"<math><annotation-xml {attrs} encoding=text/html>" + "<svg/>" * size
 
         assert_scales_linearly(source, lambda html: list(stream(html)))
+
+    def test_foreign_boundary_end_tags_scale_linearly(self) -> None:
+        assert_scales_linearly(
+            lambda size: "<div><span><svg>" + "<g>" * size + "</div>" * size,
+            lambda html: list(stream(html)),
+        )


### PR DESCRIPTION
## Summary

Reimplements the availability hardening proposed in #72 as a sequence of focused security commits. Growing parser, sanitizer, streaming, DOM cloning, and pretty-serialization structures now retain the positions or classifications they already computed instead of repeatedly rescanning attacker-controlled depth or sibling runs. Deep frameset eligibility is iterative rather than recursive.

The changelog credits @kevin-hua-kraken for #72 and @jph00 for the previously merged #68, #69, and #70 changes.

## Impact

Adversarial inputs that previously triggered quadratic processing now scale linearly. The complete 48-scenario adversarial/control matrix passes with fitted exponents near 1.0.

## Validation

- 3,930 / 3,930 tests pass
- parser differential passes
- Ruff and mypy pass
- all 48 strict scaling scenarios pass

The repository-wide coverage hook still reports the pre-existing unrelated miss at `src/justhtml/transforms/runtime.py:884`; all changed parser lines are covered.