### PR TITLE
fix: IndexError parsing misnested formatting below deep nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the open-elements position index consistent when a node is inserted below the top of the stack, or when the stack grows past the indexing depth through such an insertion. Since 3.10.0, misnested formatting markup below about thirty levels of nesting could raise `IndexError` instead of parsing, for example `"<div>" * 30 + "<i><blockquote><ul></i>"`.
+
 ## [3.10.0] - 2026-07-25
 
 ### Performance

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -7,7 +7,7 @@ engine without tokenizer or treebuilder handoffs.
 from __future__ import annotations
 
 import re
-from bisect import bisect_left, bisect_right
+from bisect import bisect_left, bisect_right, insort
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, SupportsIndex, cast
 
@@ -847,7 +847,10 @@ class _CountingStack(list[Node]):
                 if self[index].namespace in {None, "html"}:
                     return index
             return -1
-        return max((positions[-1] for positions in self._html_positions.values()), default=-1)
+        # The document root sits at index 0 and is never a match, matching the
+        # reverse scan above, which stops before it.
+        index = max((positions[-1] for positions in self._html_positions.values()), default=-1)
+        return index if index > 0 else -1
 
     def last_index_of_any(self, names: Collection[str]) -> int | None:
         if not self._indexed:
@@ -878,7 +881,9 @@ class _CountingStack(list[Node]):
                 if self[index].namespace != _PARSER_ONLY_NAMESPACE:
                     return index
             return None
-        return self._rendered_positions[-1] if self._rendered_positions else None
+        # As above, index 0 is the document root and is never a match.
+        index = self._rendered_positions[-1] if self._rendered_positions else 0
+        return index or None
 
     def last_template_boundary_index(self) -> int:
         if not self._indexed:
@@ -926,6 +931,21 @@ class _CountingStack(list[Node]):
         if self._foreign_boundaries and self._foreign_boundaries[-1] == index:
             self._foreign_boundaries.pop()
 
+    def _note_position_at(self, item: Node, index: int) -> None:
+        """Record `item` at `index`, which need not be the top of the stack.
+
+        Every list here is ascending, so a position below the top is spliced in
+        rather than appended. `_note_top_position` stays separate because the
+        binary search is worth avoiding on the push path.
+        """
+        positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
+        insort(positions.setdefault(item.name, []), index)
+        self._node_positions[item] = index
+        if item.namespace != _PARSER_ONLY_NAMESPACE:
+            insort(self._rendered_positions, index)
+        if item.namespace not in {None, "html", _PARSER_ONLY_NAMESPACE} and self._is_foreign_boundary(item):
+            insort(self._foreign_boundaries, index)
+
     def _discard_position(self, item: Node, index: int) -> None:
         positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
         bucket = positions[item.name]
@@ -952,7 +972,13 @@ class _CountingStack(list[Node]):
         return item in self._node_positions
 
     def _renumber_from(self, first_moved: int, delta: int) -> None:
-        for position in range(first_moved, len(self)):
+        # Each list here is ascending and is rewritten in place, so the nodes
+        # must be renumbered in the order that keeps every slot being written
+        # already vacated: bottom-up when they moved down, top-down when they
+        # moved up. Renumbering upward in ascending order overwrites an entry a
+        # later node in the same bucket still has to find.
+        span = range(first_moved, len(self))
+        for position in span if delta < 0 else reversed(span):
             item = self[position]
             old_position = position - delta
             positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
@@ -1011,15 +1037,15 @@ class _CountingStack(list[Node]):
             counts[name] = counts.get(name, 0) + 1
         elif len(self) >= _STACK_COUNT_THRESHOLD:
             self._name_counts = self._collect_name_counts()
+            # Crossing the threshold has to build the position index too. Every
+            # other path treats a live `_name_counts` as proof the index exists.
+            self._build_position_index()
         if was_indexed:
             if normalized_index == length:
                 self._note_top_position(item, normalized_index)
             else:
                 self._renumber_from(normalized_index + 1, 1)
-                positions = self._html_positions if item.namespace in {None, "html"} else self._other_positions
-                bucket = positions.setdefault(item.name, [])
-                bucket.insert(bisect_left(bucket, normalized_index), normalized_index)
-                self._node_positions[item] = normalized_index
+                self._note_position_at(item, normalized_index)
 
     def __setitem__(self, key: SupportsIndex, item: Node) -> None:  # type: ignore[override]
         previous_name = self[key].name

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -194,6 +194,157 @@ class TestTemplateLookupScaling(unittest.TestCase):
 
 
 class TestCountingStack(unittest.TestCase):
+    QUERY_NAME_SETS = (
+        frozenset({"applet", "caption", "html", "table", "td", "th", "marquee", "object", "template"}),
+        frozenset({"button", "div", "p"}),
+        frozenset({"table", "template", "html"}),
+        frozenset({"missing"}),
+    )
+
+    @staticmethod
+    def _indexed_copy(nodes: list) -> _CountingStack:
+        """Build a stack that answers from the index regardless of its depth."""
+        stack = _CountingStack(nodes)
+        counts = stack._collect_name_counts()
+        stack._name_counts = counts
+        stack._p_count = counts.get("p", 0)
+        stack._build_position_index()
+        return stack
+
+    def assert_indexed_and_scanned_agree(self, nodes: list) -> None:
+        """The indexed and shallow-scan paths must answer identically.
+
+        Below the depth threshold the stack answers by scanning and keeps no
+        index, so every lookup has two implementations. A document must not
+        parse differently once its stack grows past that threshold, which means
+        the two have to be checked against each other rather than only against
+        the parser's output.
+        """
+        scanned = _CountingStack(nodes)
+        assert not scanned._indexed
+        indexed = self._indexed_copy(nodes)
+
+        for name in ("div", "p", "span", "template", "table", "g", "foreignObject", "missing"):
+            assert scanned.count_of(name) == indexed.count_of(name), name
+            assert scanned.last_index_of(name) == indexed.last_index_of(name), name
+            assert scanned.last_html_index_of(name) == indexed.last_html_index_of(name), name
+            assert scanned.last_html_index_of(name, parser_only=True) == indexed.last_html_index_of(
+                name, parser_only=True
+            ), name
+        for names in self.QUERY_NAME_SETS:
+            assert scanned.last_index_of_any(names) == indexed.last_index_of_any(names), names
+            assert scanned.last_html_index_of_any(names) == indexed.last_html_index_of_any(names), names
+        assert scanned.last_foreign_boundary_index() == indexed.last_foreign_boundary_index()
+        assert scanned.last_html_index() == indexed.last_html_index()
+        assert scanned.last_rendered_index() == indexed.last_rendered_index()
+        assert scanned.last_template_boundary_index() == indexed.last_template_boundary_index()
+        for node in nodes:
+            assert (node in scanned) == (node in indexed)
+            assert scanned.index_of_node(node) == indexed.index_of_node(node)
+        absent = Element("div", {}, "html")
+        assert (absent in scanned) == (absent in indexed)
+        assert scanned.index_of_node(absent) == indexed.index_of_node(absent)
+
+    def test_indexed_and_scanned_lookups_agree_on_varied_stacks(self) -> None:
+        candidates = [
+            lambda: Element("div", {}, "html"),
+            lambda: Element("p", {}, "html"),
+            lambda: Element("table", {}, "html"),
+            lambda: Element("td", {}, "html"),
+            lambda: Template("template", {}, namespace="html"),
+            lambda: Element("template", {}, "justhtml-parser-only"),
+            lambda: Element("g", {}, "svg"),
+            lambda: Element("foreignObject", {}, "svg"),
+            lambda: Element("desc", {}, "svg"),
+            lambda: Element("mtext", {}, "math"),
+            lambda: Element("annotation-xml", {"encoding": "text/html"}, "math"),
+            lambda: Element("annotation-xml", {"encoding": "other"}, "math"),
+            lambda: Element("span", {}, "svg"),
+        ]
+        # A deterministic spread of shapes: every rotation of the candidate list
+        # truncated to several lengths, so each node kind appears at the top, in
+        # the middle, and at the bottom of a stack.
+        for rotation in range(len(candidates)):
+            ordered = candidates[rotation:] + candidates[:rotation]
+            for length in (1, 2, 5, len(ordered)):
+                nodes = [DocumentFragment()] + [make() for make in ordered[:length]]
+                self.assert_indexed_and_scanned_agree(nodes)
+
+    def assert_index_matches_contents(self, stack: _CountingStack) -> None:
+        """Every ascending list the stack maintains must still describe it."""
+        html_expected: dict[str, list[int]] = {}
+        other_expected: dict[str, list[int]] = {}
+        rendered: list[int] = []
+        boundaries: list[int] = []
+        for index, node in enumerate(stack):
+            positions = html_expected if node.namespace in {None, "html"} else other_expected
+            positions.setdefault(node.name, []).append(index)
+            if node.namespace != "justhtml-parser-only":
+                rendered.append(index)
+            if node.namespace not in {None, "html", "justhtml-parser-only"} and _CountingStack._is_foreign_boundary(
+                node
+            ):
+                boundaries.append(index)
+        assert stack._html_positions == html_expected
+        assert stack._other_positions == other_expected
+        assert stack._rendered_positions == rendered
+        assert stack._foreign_boundaries == boundaries
+        assert stack._node_positions == {node: index for index, node in enumerate(stack)}
+
+    def test_middle_insert_records_the_new_node_in_every_index(self) -> None:
+        """A node inserted below the top belongs in the ascending lists too.
+
+        The adoption agency reparents a formatting element one slot above the
+        furthest block, so this path runs for every misnested formatting tag on
+        a stack deep enough to be indexed.
+        """
+        root = DocumentFragment()
+        filler = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD)]
+        above = [Element("span", {}, "html"), Element("g", {}, "svg"), Element("span", {}, "html")]
+        stack = _CountingStack([root, *filler, *above])
+        assert stack._indexed
+
+        inserted = Element("b", {}, "html")
+        stack.insert(len(filler) + 1, inserted)
+        self.assert_index_matches_contents(stack)
+        assert stack.index_of_node(inserted) == len(filler) + 1
+        assert stack.last_index_of("span") == len(stack) - 1
+
+        # Removing a node renumbers the same span back down again.
+        stack.remove(inserted)
+        self.assert_index_matches_contents(stack)
+
+    def test_insert_that_crosses_the_depth_threshold_builds_the_index(self) -> None:
+        """Growing past the threshold through `insert` must index, like `append`.
+
+        Every other path treats a live `_name_counts` as proof that the position
+        index exists, so setting one without the other leaves the next push
+        reading attributes that were never assigned.
+        """
+        root = DocumentFragment()
+        stack = _CountingStack([root])
+        while len(stack) < _STACK_COUNT_THRESHOLD - 1:
+            stack.append(Element("div", {}, "html"))
+        assert not stack._indexed
+
+        stack.insert(1, Element("span", {}, "html"))
+        assert stack._indexed
+        self.assert_index_matches_contents(stack)
+
+        pushed = Element("b", {}, "html")
+        stack.append(pushed)
+        self.assert_index_matches_contents(stack)
+        assert stack.last_index_of("b") == len(stack) - 1
+
+    def test_misnested_formatting_below_deep_nesting_parses(self) -> None:
+        """Regression: the reparent above corrupted the index and then raised.
+
+        Ordinary markup, no adversarial size -- only enough nesting to put the
+        open-elements stack past the depth at which it is indexed.
+        """
+        document = JustHTML("<div>" * 30 + "<i><blockquote><ul></i>")
+        assert document.to_html(pretty=False).count("<ul>") == 1
+
     def test_indexed_template_queries_skip_namesakes_in_each_namespace(self) -> None:
         root = DocumentFragment()
         filler = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD)]

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -314,6 +314,22 @@ class TestCountingStack(unittest.TestCase):
         stack.remove(inserted)
         self.assert_index_matches_contents(stack)
 
+        # The three kinds of node the ascending lists treat differently: an
+        # ordinary rendered element, a foreign scope boundary, and a
+        # parser-only node that is in neither the rendered list nor the
+        # boundary list.
+        for node in (
+            Element("b", {}, "html"),
+            Element("foreignObject", {}, "svg"),
+            Element("template", {}, "justhtml-parser-only"),
+        ):
+            stack.insert(len(filler) + 1, node)
+            self.assert_index_matches_contents(stack)
+            assert stack.index_of_node(node) == len(filler) + 1
+        for node in reversed(stack[len(filler) + 1 : len(filler) + 4]):
+            stack.remove(node)
+            self.assert_index_matches_contents(stack)
+
     def test_insert_that_crosses_the_depth_threshold_builds_the_index(self) -> None:
         """Growing past the threshold through `insert` must index, like `append`.
 


### PR DESCRIPTION
## Summary

Since 3.10.0, misnested formatting markup below about thirty levels of nesting
raises `IndexError` instead of parsing. Ordinary markup, no adversarial size:

```python
JustHTML("<div>" * 30 + "<i><blockquote><ul></i>")
# IndexError: list assignment index out of range
```

3.9.0 parses this. So does 3.10.0 with this change, to the same tree.

It reproduces with the default constructor, sanitizer on, from depth 26 upward
&mdash; that is, as soon as the open-elements stack crosses
`_STACK_COUNT_THRESHOLD` and switches to the position index.

## Cause

`_CountingStack.insert()` records a node placed below the top of the stack in
the per-name position maps and in `_node_positions`, but not in
`_rendered_positions` or `_foreign_boundaries`. Those two lists then describe a
stack that no longer exists:

```
insert(34, <Element>)
_rendered_positions [.. 31, 32, 33, 35] != [.. 31, 32, 33, 34, 35]
```

`_renumber_from()` compounds it. Every list it maintains is ascending and it
rewrites them in place while walking upward, so when nodes shift *up* it
overwrites an entry that a later node in the same bucket still has to find.
Walking down is fine; walking up is not.

A later `remove()` binary-searches a list that is now short and assigns past its
end.

The adoption agency reparents a formatting element one slot above the furthest
block &mdash; `stack.insert(furthest_stack_index + 1, new_formatting_element)`
&mdash; so both paths run for every misnested formatting tag on a stack deep
enough to be indexed. That is the only caller of `insert()`, which is why this
did not surface sooner.

Two further inconsistencies came out of the same area, both found by the new
test rather than by a crash:

- Growing past the indexing depth through `insert()` set the name counts but
  never built the position index, while every other path treats a live count map
  as proof that the index exists.
- `last_html_index()` and `last_rendered_index()` include index 0 on the indexed
  path, where the reverse scans they stand in for stop before the document root.
  I have not found markup that reaches those two &mdash; the parser keeps `html`
  and `body` above the root &mdash; but the two implementations of one lookup
  should not disagree.

## Fix

`_note_position_at()` records a node at an arbitrary index in every list, by
binary search, mirroring the existing `_discard_position()`. `insert()` uses it,
and builds the index when it crosses the depth threshold. `_renumber_from()`
walks top-down when nodes move up. The two lookups above exclude index 0.

Nine lines of implementation.

## Correctness

The new `test_indexed_and_scanned_lookups_agree_on_varied_stacks` checks the
indexed and scanning implementations of every `_CountingStack` lookup against
each other, over rotations of thirteen node kinds truncated to several depths.
That is what found the last three items above; a per-input regression test would
have found none of them.

- Full suite 3,956 / 3,956, ruff and mypy clean.
- 3,000 generated deep-nesting documents parse to output **byte-identical to
  3.9.0**. On 3.10.0, 494 of them raise `IndexError` (483 with the sanitizer on).
- A randomized differential of `_CountingStack` against brute-force list scans
  &mdash; 400 seeds, ~400 mutations each, checking every lookup after every
  mutation &mdash; passes. It fails on 3.10.0.
- No measurable throughput change: web100k parse over 1,000 documents is within
  noise of `main` (paired medians, order rotated across passes).

Four of the added tests fail on `main`.
