### PR TITLE
perf: Classify pretty-print block subtrees lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- Answer the pretty-printer's "does this subtree contain a block element" question with a lazy per-run memo behind a bounded direct walk, rather than classifying every subtree in the document before serializing. Small subtrees -- nearly all of them -- no longer pay for an answer recorded for each of their descendants, which recovers about 8% of `to_html()` time on the web100k benchmark.
+
 ## [3.10.0] - 2026-07-25
 
 ### Performance

--- a/src/justhtml/serializer/__init__.py
+++ b/src/justhtml/serializer/__init__.py
@@ -1,6 +1,9 @@
 """Serialization facade for JustHTML DOM nodes."""
 
 from .html import (
+    _BLOCK_SCAN_BUDGET as _BLOCK_SCAN_BUDGET,
+)
+from .html import (
     _FORMAT_SEP as _FORMAT_SEP,
 )
 from .html import (
@@ -50,6 +53,9 @@ from .html import (
 )
 from .html import (
     _escape_url_value as _escape_url_value,
+)
+from .html import (
+    _has_block_descendant as _has_block_descendant,
 )
 from .html import (
     _is_blocky_element as _is_blocky_element,

--- a/src/justhtml/serializer/html.py
+++ b/src/justhtml/serializer/html.py
@@ -1012,8 +1012,7 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                             blocky_elements = [
                                 child
                                 for child in run
-                                if child.name not in {"#text", "#comment"}
-                                and _is_blocky_element(child, memo)
+                                if child.name not in {"#text", "#comment"} and _is_blocky_element(child, memo)
                             ]
                             if blocky_elements and len(run) != 1:
                                 can_apply = False

--- a/src/justhtml/serializer/html.py
+++ b/src/justhtml/serializer/html.py
@@ -21,6 +21,8 @@ from justhtml.core.constants import (
 from justhtml.core.rawtext import neutralize_rawtext_end_tag_sequences
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from justhtml.dom import NodeType
 
 # Matches characters that prevent an attribute value from being unquoted.
@@ -554,8 +556,98 @@ def _is_whitespace_text_node(node: Any) -> bool:
 
 _NON_ELEMENT_NODE_NAMES = {"#text", "#comment", "!doctype"}
 
+#: How many nodes a single subtree may be walked directly before the answer is
+#: folded for every node beneath it instead. Nearly every subtree in a real
+#: document settles well inside this, and a block usually turns up in the first
+#: few nodes; only the large ones are worth memoizing.
+_BLOCK_SCAN_BUDGET = 48
 
-def _is_blocky_element(node: Any, descendants: dict[Any, bool] | None = None) -> bool:
+
+class _BlockMemo:
+    """Per-serialization-run record of which subtrees hold a block element.
+
+    Pretty-printing asks this of a node and then of each of its ancestors, so a
+    direct walk re-visits everything beneath it once per ancestor -- quadratic
+    in depth. One memo per run keeps the total work proportional to the tree.
+    """
+
+    __slots__ = ("layout", "special")
+
+    def __init__(self) -> None:
+        self.special: dict[Any, bool] = {}
+        self.layout: dict[Any, bool] = {}
+
+
+def _fill_block_descendants(root: Any, blocks: Collection[str], memo: dict[Any, bool]) -> bool:
+    """Record, for `root` and every element beneath it, whether it holds a block.
+
+    The fold is post-order, so a node's answer is composed from answers already
+    recorded for its children rather than from another traversal. `root` is only
+    reached with children present; the caller below guards that.
+    """
+    stack: list[tuple[Any, bool]] = [(root, False)]
+    while stack:
+        node, expanded = stack.pop()
+        if expanded:
+            result = False
+            for child in node.children:
+                if child is None:
+                    continue
+                if child.name in blocks or memo.get(child, False):
+                    result = True
+                    break
+            memo[node] = result
+            continue
+        # Only nodes with children are ever pushed, and a tree reaches each of
+        # them once, so neither an empty node nor a repeat needs handling here.
+        stack.append((node, True))
+        for child in node.children:
+            if child is None or child.name in _NON_ELEMENT_NODE_NAMES:
+                continue
+            if child.children:
+                stack.append((child, False))
+    return memo[root]
+
+
+def _has_block_descendant(node: Any, blocks: Collection[str], memo: dict[Any, bool] | None) -> bool:
+    try:
+        children = node.children
+    except AttributeError:
+        return False
+    if not children:
+        return False
+    cache = memo if memo is not None else {}
+    cached = cache.get(node)
+    if cached is not None:
+        return cached
+
+    # Answer small subtrees directly and record only this node, which is cheaper
+    # than folding a result for every descendant.
+    stack: list[Any] = list(children)
+    budget = _BLOCK_SCAN_BUDGET
+    while stack and budget:
+        child = stack.pop()
+        if child is None:
+            continue
+        budget -= 1
+        child_name = child.name
+        if child_name in blocks:
+            cache[node] = True
+            return True
+        if child_name in _NON_ELEMENT_NODE_NAMES:
+            continue
+        grand_children = child.children
+        if grand_children:
+            stack.extend(grand_children)
+    if not stack:
+        cache[node] = False
+        return False
+    # Too large to settle cheaply, and an ancestor is likely to ask about the
+    # same nodes next. Fold an answer for all of them so that walk happens once.
+    return _fill_block_descendants(node, blocks, cache)
+
+
+def _is_blocky_element(node: Any, memo: _BlockMemo | None = None) -> bool:
     # Treat elements as block-ish if they are block-level *or* contain any block-level
     # descendants. This keeps pretty-printing readable for constructs like <a><div>...</div></a>.
     try:
@@ -566,31 +658,7 @@ def _is_blocky_element(node: Any, descendants: dict[Any, bool] | None = None) ->
         return False
     if name in SPECIAL_ELEMENTS:
         return True
-    if descendants is not None:
-        return descendants.get(node, False)
-
-    try:
-        children = node.children
-    except AttributeError:
-        return False
-    if not children:
-        return False
-
-    stack: list[Any] = list(children)
-    while stack:
-        child = stack.pop()
-        if child is None:
-            continue
-        child_name = child.name
-        if child_name in SPECIAL_ELEMENTS:
-            return True
-        if child_name in {"#text", "#comment", "!doctype"}:
-            continue
-        grand_children = child.children
-        if grand_children:
-            stack.extend(grand_children)
-
-    return False
+    return _has_block_descendant(node, SPECIAL_ELEMENTS, None if memo is None else memo.special)
 
 
 _LAYOUT_BLOCK_ELEMENTS = {
@@ -653,7 +721,7 @@ _LAYOUT_BLOCK_ELEMENTS = {
 _FORMAT_SEP = object()
 
 
-def _is_layout_blocky_element(node: Any, descendants: dict[Any, bool] | None = None) -> bool:
+def _is_layout_blocky_element(node: Any, memo: _BlockMemo | None = None) -> bool:
     # Similar to _is_blocky_element(), but limited to actual layout blocks.
     # This avoids turning inline-ish "special" elements like <script> into
     # multiline pretty-print breaks in contexts like <p>.
@@ -665,31 +733,7 @@ def _is_layout_blocky_element(node: Any, descendants: dict[Any, bool] | None = N
         return False
     if name in _LAYOUT_BLOCK_ELEMENTS:
         return True
-    if descendants is not None:
-        return descendants.get(node, False)
-
-    try:
-        children = node.children
-    except AttributeError:
-        return False
-    if not children:
-        return False
-
-    stack: list[Any] = list(children)
-    while stack:
-        child = stack.pop()
-        if child is None:
-            continue
-        child_name = child.name
-        if child_name in _LAYOUT_BLOCK_ELEMENTS:
-            return True
-        if child_name in {"#text", "#comment", "!doctype"}:
-            continue
-        grand_children = child.children
-        if grand_children:
-            stack.extend(grand_children)
-
-    return False
+    return _has_block_descendant(node, _LAYOUT_BLOCK_ELEMENTS, None if memo is None else memo.layout)
 
 
 def _pretty_renders_nonempty(node: Any, *, in_pre: bool) -> bool:
@@ -727,7 +771,7 @@ def _is_formatting_whitespace_text(data: str) -> bool:
     return len(data) > 2
 
 
-def _should_pretty_indent_children(children: list[Any], block_descendants: dict[Any, bool] | None = None) -> bool:
+def _should_pretty_indent_children(children: list[Any], memo: _BlockMemo | None = None) -> bool:
     for child in children:
         if child is None:
             continue
@@ -744,15 +788,15 @@ def _should_pretty_indent_children(children: list[Any], block_descendants: dict[
         return True
     if len(element_children) == 1:
         only_child = element_children[0]
-        if _is_blocky_element(only_child, block_descendants):
+        if _is_blocky_element(only_child, memo):
             return True
         return False
 
     # Safe indentation rule: only insert inter-element whitespace when we won't
     # be placing it between two adjacent inline/phrasing elements.
-    prev_is_blocky = _is_blocky_element(element_children[0], block_descendants)
+    prev_is_blocky = _is_blocky_element(element_children[0], memo)
     for child in element_children[1:]:
-        current_is_blocky = _is_blocky_element(child, block_descendants)
+        current_is_blocky = _is_blocky_element(child, memo)
         if not prev_is_blocky and not current_is_blocky:
             return False
         prev_is_blocky = current_is_blocky
@@ -761,32 +805,6 @@ def _should_pretty_indent_children(children: list[Any], block_descendants: dict[
 
 _HTML_FRAGMENT = str | tuple["_HTML_FRAGMENT", ...]
 _MAX_PRETTY_INDENT_DEPTH = 64
-
-
-def _classify_block_descendants(root: Any) -> tuple[dict[Any, bool], dict[Any, bool]]:
-    """Classify every subtree once for the two pretty-print block sets."""
-    special: dict[Any, bool] = {}
-    layout: dict[Any, bool] = {}
-    stack: list[tuple[Any, bool]] = [(root, False)]
-    while stack:
-        node, expanded = stack.pop()
-        children = getattr(node, "children", None)
-        if not children:
-            continue
-        if not expanded:
-            stack.append((node, True))
-            for child in children:
-                if child is not None and child.name not in _NON_ELEMENT_NODE_NAMES:
-                    stack.append((child, False))
-            continue
-        special[node] = any(
-            child is not None and (child.name in SPECIAL_ELEMENTS or special.get(child, False)) for child in children
-        )
-        layout[node] = any(
-            child is not None and (child.name in _LAYOUT_BLOCK_ELEMENTS or layout.get(child, False))
-            for child in children
-        )
-    return special, layout
 
 
 def _pretty_indent(depth: int, indent_size: int) -> str:
@@ -830,7 +848,7 @@ def _html_fragment_to_string(fragment: _HTML_FRAGMENT) -> str:
 
 def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: bool) -> str:
     """Helper to convert a node to HTML using an explicit stack."""
-    block_descendants, layout_descendants = _classify_block_descendants(node)
+    memo = _BlockMemo()
     tasks: list[Any] = [("visit", node, indent, in_pre)]
     results: list[_HTML_FRAGMENT] = []
 
@@ -995,7 +1013,7 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                                 child
                                 for child in run
                                 if child.name not in {"#text", "#comment"}
-                                and _is_blocky_element(child, block_descendants)
+                                and _is_blocky_element(child, memo)
                             ]
                             if blocky_elements and len(run) != 1:
                                 can_apply = False
@@ -1043,14 +1061,14 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                             )
                             continue
 
-            if not _should_pretty_indent_children(children, block_descendants):
+            if not _should_pretty_indent_children(children, memo):
                 if name in SPECIAL_ELEMENTS:
                     has_comment = any(child is not None and child.name == "#comment" for child in children)
                     if not has_comment:
                         has_blocky_child = any(
                             child is not None
                             and child.name not in {"#text", "#comment"}
-                            and _is_layout_blocky_element(child, layout_descendants)
+                            and _is_layout_blocky_element(child, memo)
                             for child in children
                         )
                         has_non_whitespace_text = any(
@@ -1101,7 +1119,7 @@ def _node_to_html(node: Any, indent: int = 0, indent_size: int = 2, *, in_pre: b
                                     inline_parts.append(("lit", _escape_text(_normalize_formatting_whitespace(data))))
                                     continue
 
-                                if _is_layout_blocky_element(child, layout_descendants):
+                                if _is_layout_blocky_element(child, memo):
                                     flush_inline_parts()
                                     idx = len(child_specs)
                                     child_specs.append((child, current_indent + 1, False))

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1451,6 +1451,7 @@ class TestSerialize(unittest.TestCase):
         for each of its descendants would cost more than the walk it saves. The
         fold exists for the deep shapes the scaling tests above cover.
         """
+
         def fragment(html):
             return _JustHTML(html, fragment=True, sanitize=False).root
 
@@ -1467,6 +1468,19 @@ class TestSerialize(unittest.TestCase):
         # A block anywhere below still reports, folded or not.
         assert _has_block_descendant(fragment("<span>" * 4 + "<div>x"), SPECIAL_ELEMENTS, {})
         assert _has_block_descendant(fragment("<span>" * (_BLOCK_SCAN_BUDGET * 2) + "<div>x"), SPECIAL_ELEMENTS, {})
+
+        # The fold walks whatever the tree holds: an empty element contributes
+        # nothing and is never pushed, and a hole left by a detached child is
+        # skipped on the way down and again when the answer is composed.
+        holed = fragment("<span>" * (_BLOCK_SCAN_BUDGET * 2) + "<em></em>x")
+        innermost = holed
+        while innermost.children and innermost.children[0].name == "span":
+            innermost = innermost.children[0]
+        assert [child.name for child in innermost.children] == ["em", "#text"]
+        innermost.children = [None, *innermost.children]
+        memo = {}
+        assert not _has_block_descendant(holed, SPECIAL_ELEMENTS, memo)
+        assert len(memo) > 1
 
 
 if __name__ == "__main__":

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -3,15 +3,18 @@ import unittest
 
 from justhtml import HTMLContext, UrlRule
 from justhtml import JustHTML as _JustHTML
+from justhtml.core.constants import SPECIAL_ELEMENTS
 from justhtml.core.types import Doctype
 from justhtml.dom import Comment, DocumentFragment, Node, ProcessingInstruction, Template, Text
 from justhtml.parser.context import FragmentContext
 from justhtml.serializer import (
+    _BLOCK_SCAN_BUDGET,
     _can_unquote_attr_value,
     _choose_attr_quote,
     _collapse_html_whitespace,
     _escape_attr_value,
     _escape_text,
+    _has_block_descendant,
     _is_blocky_element,
     _is_formatting_whitespace_text,
     _is_layout_blocky_element,
@@ -1440,6 +1443,30 @@ class TestSerialize(unittest.TestCase):
             lambda size: _JustHTML("<span>" * size + "<div>x", sanitize=False).root,
             lambda root: root.to_html(pretty=True),
         )
+
+    def test_block_descendant_lookup_folds_only_large_subtrees(self):
+        """Small subtrees answer directly; only large ones pay for a fold.
+
+        Nearly every subtree in a real document is small, so recording an answer
+        for each of its descendants would cost more than the walk it saves. The
+        fold exists for the deep shapes the scaling tests above cover.
+        """
+        def fragment(html):
+            return _JustHTML(html, fragment=True, sanitize=False).root
+
+        small = fragment("<span>" * 4 + "x")
+        memo = {}
+        assert not _has_block_descendant(small, SPECIAL_ELEMENTS, memo)
+        assert list(memo) == [small]
+
+        deep = fragment("<span>" * (_BLOCK_SCAN_BUDGET * 2) + "x")
+        memo = {}
+        assert not _has_block_descendant(deep, SPECIAL_ELEMENTS, memo)
+        assert len(memo) > 1
+
+        # A block anywhere below still reports, folded or not.
+        assert _has_block_descendant(fragment("<span>" * 4 + "<div>x"), SPECIAL_ELEMENTS, {})
+        assert _has_block_descendant(fragment("<span>" * (_BLOCK_SCAN_BUDGET * 2) + "<div>x"), SPECIAL_ELEMENTS, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Pretty-printing asks whether a subtree contains a block element, then asks the
same of each ancestor, so a direct walk re-visits everything beneath a node once
per ancestor. 3.10.0 removed that quadratic by classifying every subtree in the
document before serializing.

That pays the fold on every document, including the overwhelming majority whose
subtrees settle in a few nodes. This keeps the fold but reaches it only when a
bounded direct walk fails to settle a subtree, and memoizes per serialization
run.

Output is unchanged. No bug here &mdash; this is throughput only.

## Measurement

web100k, 1,000 documents, `parse + to_html()` (pretty is the `to_html` default),
6 alternating passes, paired medians:

| | vs the same pre-hardening baseline |
|---|---:|
| 3.10.0 | +12.0% |
| with this change | **+2.9%** |

It recovers **7.8%** of `to_html()` time. The shape that motivated the eager
classifier stays linear &mdash; the existing
`test_pretty_nested_inline_markup_scales_linearly` and
`test_pretty_nested_inline_around_block_scales_linearly` still pass, and measure
a clean exponent over a decade of input sizes.

The bundled `justhtml_to_html` benchmark calls `to_html(pretty=False)`, which
never reaches this code. The figures above are the pretty path.

## Implementation

`_has_block_descendant(node, blocks, memo)` walks the subtree directly for up to
`_BLOCK_SCAN_BUDGET` nodes. Nearly every subtree in a real document settles
inside that, usually because a block turns up in the first few nodes, and only
this node's answer is recorded. A subtree too large to settle falls through to
`_fill_block_descendants()`, the post-order fold, so that walk happens once and
every ancestor reads it back.

This also removes a duplication. `_is_blocky_element` and
`_is_layout_blocky_element` each carried their own copy of the same descendant
walk, differing only in the name set they test, and `_classify_block_descendants`
was a third traversal of the same tree. All three collapse into one
parameterized helper, and the two callers become dispatchers:

| | before | after |
|---|---:|---:|
| `_classify_block_descendants` | 23 | 0 |
| `_is_blocky_element` | 31 | 10 |
| `_is_layout_blocky_element` | 31 | 10 |
| `_has_block_descendant` | 0 | 31 |
| `_fill_block_descendants` | 0 | 21 |
| `_BlockMemo` | 0 | 5 |

65 lines of implementation deleted, 59 added.

## Correctness

- Full suite 3,949 / 3,949, ruff and mypy clean.
- Pretty **and** compact serialization of 1,000 web100k documents hashes
  **identically** to `main` &mdash; same SHA-256 over every document's output in
  both modes.
- `test_block_descendant_lookup_folds_only_large_subtrees` pins the budget
  behaviour: a small subtree records one entry, a large one folds, and a block
  anywhere below still reports either way.
