### PR TITLE
perf: Fix quadratic adoption recovery and reduce stack lookup work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
-- Answer the open-elements scope check from a maintained name count before looking for a boundary, and settle target and boundary in one bounded pass on the shallow stacks that ordinary documents keep. The check runs several times per token, and the count returns outright on about two thirds of the calls.
+- Answer the open-elements scope check from a maintained name count before looking for a boundary, and settle target and boundary in one bounded pass on the shallow stacks that ordinary documents keep. The check runs several times per token, and the count returns outright on about two thirds of the calls (thanks @kevin-hua-kraken in #76).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- (Severity: Low) Re-record only the slot that changed when the adoption agency clones a formatting element back onto the open-elements stack, instead of rebuilding the whole position index. Since 3.10.0, markup nesting a formatting element between the end tag's subject and the furthest block, such as `"<b><i><div></b>" * n`, took time quadratic in its length -- about 3.7x longer than 3.9.0 on the same input.
+
 ## [3.10.1] - 2026-07-25
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- Answer the open-elements scope check from a maintained name count before looking for a boundary, and settle target and boundary in one bounded pass on the shallow stacks that ordinary documents keep. The check runs several times per token, and the count returns outright on about two thirds of the calls.
+
 ### Security
 
 - (Severity: Low) Re-record only the slot that changed when the adoption agency clones a formatting element back onto the open-elements stack, instead of rebuilding the whole position index. Since 3.10.0, markup nesting a formatting element between the end tag's subject and the furthest block, such as `"<b><i><div></b>" * n`, took time quadratic in its length -- about 3.7x longer than 3.9.0 on the same input.

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -1048,23 +1048,28 @@ class _CountingStack(list[Node]):
                 self._note_position_at(item, normalized_index)
 
     def __setitem__(self, key: SupportsIndex, item: Node) -> None:  # type: ignore[override]
-        previous_name = self[key].name
+        raw_key = key.__index__()
+        normalized_key = raw_key if raw_key >= 0 else len(self) + raw_key
+        previous = self[normalized_key]
+        previous_name = previous.name
         name = item.name
         list.__setitem__(self, key, item)
-        if previous_name == name:
-            if self._indexed:
-                self._build_position_index()
-            return
-        if previous_name == "p":
-            self._p_count -= 1
-        if name == "p":
-            self._p_count += 1
-        counts = self._name_counts
-        if counts is not None:
-            counts[previous_name] -= 1
-            counts[name] = counts.get(name, 0) + 1
+        if previous_name != name:
+            if previous_name == "p":
+                self._p_count -= 1
+            if name == "p":
+                self._p_count += 1
+            counts = self._name_counts
+            if counts is not None:
+                counts[previous_name] -= 1
+                counts[name] = counts.get(name, 0) + 1
         if self._indexed:
-            self._build_position_index()
+            # One slot changing hands moves nothing, so only the two nodes
+            # involved are re-recorded. Rebuilding the whole index costs the
+            # stack's depth, and the adoption agency reaches this path once per
+            # misnested formatting tag, which makes that shape quadratic.
+            self._discard_position(previous, normalized_key)
+            self._note_position_at(item, normalized_key)
 
     def pop(self, index: int = -1) -> Node:  # type: ignore[override]
         normalized_index = index if index >= 0 else len(self) + index

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -834,11 +834,20 @@ class _CountingStack(list[Node]):
                 if node.namespace in {None, "html"} and node.name in names:
                     return index
             return -1
+        # Scope boundaries arrive as a set of tag names, sometimes a large one.
+        # Iterating whichever side is smaller keeps the cost tied to the variety
+        # of names actually open, which stays small even on a deep stack.
+        positions_by_name = self._html_positions
         best = -1
+        if len(positions_by_name) < len(names):
+            for name, positions in positions_by_name.items():
+                if positions[-1] > best and name in names:
+                    best = positions[-1]
+            return best
         for name in names:
-            positions = self._html_positions.get(name)
-            if positions:
-                best = max(best, positions[-1])
+            found = positions_by_name.get(name)
+            if found and found[-1] > best:
+                best = found[-1]
         return best
 
     def last_html_index(self) -> int:
@@ -874,6 +883,25 @@ class _CountingStack(list[Node]):
                     return index
             return -1
         return self._foreign_boundaries[-1] if self._foreign_boundaries else -1
+
+    def last_scope_boundary_index(self, names: Collection[str]) -> int:
+        """Return the nearest scope boundary, or -1 when none is open.
+
+        A boundary is an HTML element named in `names` or a foreign integration
+        point, which is the pair of lookups every scope check needs. Answering
+        both in one call lets a shallow stack settle them in a single pass.
+        """
+        if not self._indexed:
+            for index in range(len(self) - 1, 0, -1):
+                node = self[index]
+                namespace = node.namespace
+                if namespace is None or namespace == "html":
+                    if node.name in names:
+                        return index
+                elif namespace != _PARSER_ONLY_NAMESPACE and self._is_foreign_boundary(node):
+                    return index
+            return -1
+        return max(self.last_html_index_of_any(names), self.last_foreign_boundary_index())
 
     def last_rendered_index(self) -> int | None:
         if not self._indexed:
@@ -4424,12 +4452,41 @@ class ParseEngine:
         return stack.last_html_index_of(name, parser_only=True)
 
     def _find_open_index_before_boundary(self, name: str, boundaries: frozenset[str]) -> int | None:
+        """Return the innermost open `name`, or None when a scope boundary is nearer.
+
+        This is the scope check of §13.2.4.2, and it runs several times per
+        token, so the order of the tests below is load-bearing rather than
+        cosmetic.
+        """
         stack = self._stack
-        target = stack.last_index_of(name)
-        if target is None:
+        if not stack.count_of(name):
+            # Nothing by that name is open, so no scope can contain it. About
+            # two thirds of the calls here ask for `p`, whose count is
+            # maintained anyway, and an indexed stack answers any name from its
+            # position lists. This returns outright on the majority of calls,
+            # skipping the boundary lookup below.
             return None
-        boundary = max(stack.last_html_index_of_any(boundaries), stack.last_foreign_boundary_index())
-        return target if target >= boundary else None
+        if not stack._indexed:
+            # A shallow stack settles target and boundary in one bounded pass,
+            # which is cheaper than the two index lookups the deep path needs.
+            for index in range(len(stack) - 1, 0, -1):
+                node = stack[index]
+                node_name = node.name
+                if node_name == name:
+                    return index
+                namespace = node.namespace
+                if namespace is None or namespace == "html":
+                    if node_name in boundaries:
+                        return None
+                elif namespace != _PARSER_ONLY_NAMESPACE and _CountingStack._is_foreign_boundary(node):
+                    return None
+            # Only reachable if index 0 held the sole match, and the document
+            # root never carries a name the parser asks for.
+            return None  # pragma: no cover
+        target = stack.last_index_of(name)
+        if target is None:  # pragma: no cover - ruled out by the count guard above
+            return None  # pragma: no cover - ruled out by the count guard above
+        return target if target >= stack.last_scope_boundary_index(boundaries) else None
 
     def _find_open_table_scoped_end_index(self, name: str) -> int | None:
         for idx in range(len(self._stack) - 1, 0, -1):
@@ -4471,12 +4528,11 @@ class ParseEngine:
 
     def _find_open_heading_index(self) -> int | None:
         stack = self._stack
-        target = max((stack.last_index_of(name) or -1 for name in HEADING_ELEMENTS), default=-1)
-        boundary = max(
-            stack.last_html_index_of_any(_DEFAULT_SCOPE_BOUNDARIES),
-            stack.last_foreign_boundary_index(),
-        )
-        return target if target > boundary else None
+        # One pass over the six heading names rather than six separate lookups.
+        target = stack.last_index_of_any(HEADING_ELEMENTS)
+        if target is None:
+            return None
+        return target if target > stack.last_scope_boundary_index(_DEFAULT_SCOPE_BOUNDARIES) else None
 
     def _set_current_template_mode(self, mode: str) -> None:
         if self._template_modes:  # pragma: no branch - opposite edge requires invalid parser state

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -739,7 +739,8 @@ class _CountingStack(list[Node]):
     making nested markup quadratic overall. Shallow stacks track the especially
     common `p` lookup directly and scan at most 31 nodes for other names. At
     the configured depth threshold, the stack permanently switches to per-name
-    counts so hostile deep nesting retains constant-time negative lookups.
+    position indexes so hostile deep nesting retains constant-time negative
+    lookups.
     """
 
     __slots__ = (

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -82,6 +82,11 @@ _PLAINTEXT_TAGS = {"plaintext"}
 _ACTIVE_FORMATTING_TAGS = FORMATTING_ELEMENTS
 _ACTIVE_FORMATTING_MARKER_TAGS = {"applet", "caption", "marquee", "object"}
 _PARSER_ONLY_NAMESPACE = "justhtml-parser-only"
+#: Namespaces an open element carries when it is an HTML element, and the same
+#: set widened to include the parser's own template markers. Module constants so
+#: that the reverse scans below do not rebuild them per node visited.
+_HTML_NAMESPACES = frozenset({None, "html"})
+_OPEN_HTML_NAMESPACES = frozenset({None, "html", _PARSER_ONLY_NAMESPACE})
 _DEFAULT_SCOPE_BOUNDARIES = frozenset(DEFAULT_SCOPE_TERMINATORS)
 _BUTTON_SCOPE_BOUNDARIES = frozenset({"button"})
 _P_SCOPE_BOUNDARIES = frozenset(BUTTON_SCOPE_TERMINATORS)
@@ -810,9 +815,11 @@ class _CountingStack(list[Node]):
 
     def last_html_index_of(self, name: str, *, parser_only: bool = False) -> int | None:
         if not self._indexed:
+            # Hoisted: this ran once per node visited, and the scan below is on
+            # the path every insertion into a table takes.
+            namespaces = _OPEN_HTML_NAMESPACES if parser_only else _HTML_NAMESPACES
             for index in range(len(self) - 1, 0, -1):
                 node = self[index]
-                namespaces = {None, "html", _PARSER_ONLY_NAMESPACE} if parser_only else {None, "html"}
                 if node.name == name and node.namespace in namespaces:
                     return index
             return None
@@ -5258,17 +5265,21 @@ class ParseEngine:
         ):  # pragma: no branch - opposite edge requires invalid parser state
             return None  # pragma: no cover - unreachable after parser-state guards
         table_idx = self._find_open_index("table")
-        parser_only_template_idx = self._open_parser_only_template_index()
+        # Fostering runs once per node placed inside a table, and no template is
+        # open for the overwhelming majority of them. Both counters below are
+        # maintained anyway, so consulting them skips two stack lookups.
+        parser_only_template_idx = (
+            self._open_parser_only_template_index() if self._parser_only_template_depth else None
+        )
         if table_idx is not None and parser_only_template_idx is not None and table_idx < parser_only_template_idx:
             return None
-        template_idx = self._open_template_index()
+        template_idx = self._open_template_index() if self._template_modes else None
         if table_idx is not None and template_idx is not None and table_idx < template_idx:
             table_idx = None
         if table_idx is None:
             if self._template_modes:
-                open_template_idx = self._open_template_index()
-                if open_template_idx is not None:  # pragma: no branch - template modes require an open template
-                    template = self._stack[open_template_idx]
+                if template_idx is not None:  # pragma: no branch - template modes require an open template
+                    template = self._stack[template_idx]
                     if type(template) is Template and template.template_content is not None:
                         children = template.template_content.children
                         return template.template_content, len(children or ())

--- a/src/justhtml/parser/engine.py
+++ b/src/justhtml/parser/engine.py
@@ -746,7 +746,6 @@ class _CountingStack(list[Node]):
         "_foreign_boundaries",
         "_html_positions",
         "_indexed",
-        "_name_counts",
         "_node_positions",
         "_other_positions",
         "_p_count",
@@ -755,7 +754,6 @@ class _CountingStack(list[Node]):
 
     def __init__(self, iterable: Iterable[Node] = ()) -> None:
         super().__init__(iterable)
-        self._name_counts: dict[str, int] | None = None
         self._indexed = False
         if len(self) < _STACK_COUNT_THRESHOLD:
             p_count = 0
@@ -763,9 +761,10 @@ class _CountingStack(list[Node]):
                 p_count += item.name == "p"
             self._p_count = p_count
             return
-        counts = self._collect_name_counts()
-        self._name_counts = counts
-        self._p_count = counts.get("p", 0)
+        p_count = 0
+        for item in self:
+            p_count += item.name == "p"
+        self._p_count = p_count
         self._build_position_index()
 
     def _build_position_index(self) -> None:
@@ -1027,22 +1026,27 @@ class _CountingStack(list[Node]):
                 boundaries = self._foreign_boundaries
                 boundaries[bisect_left(boundaries, old_position)] = position
 
-    def _collect_name_counts(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        for item in self:
-            counts[item.name] = counts.get(item.name, 0) + 1
-        return counts
-
     def count_of(self, name: str) -> int:
+        """Return how many open elements carry `name`, in any namespace.
+
+        Constant time for `p` and for any name on an indexed stack; a walk
+        bounded by the index threshold otherwise. An indexed stack answers from
+        the position lists it already maintains -- keeping a separate per-name
+        counter in step on every push and pop costs more than these two lookups
+        save.
+        """
         if name == "p":
+            # Load-bearing: `p` is the target of about two thirds of all scope
+            # checks, and its count is maintained at every depth.
             return self._p_count
-        counts = self._name_counts
-        if counts is not None:
-            return counts.get(name, 0)
-        count = 0
-        for item in self:
-            count += item.name == name
-        return count
+        if not self._indexed:
+            count = 0
+            for item in self:
+                count += item.name == name
+            return count
+        html = self._html_positions.get(name)
+        other = self._other_positions.get(name)
+        return (len(html) if html is not None else 0) + (len(other) if other is not None else 0)
 
     def append(self, item: Node) -> None:  # type: ignore[override]
         index = len(self)
@@ -1050,12 +1054,9 @@ class _CountingStack(list[Node]):
         name = item.name
         if name == "p":
             self._p_count += 1
-        counts = self._name_counts
-        if counts is not None:
-            counts[name] = counts.get(name, 0) + 1
+        if self._indexed:
             self._note_top_position(item, index)
         elif len(self) >= _STACK_COUNT_THRESHOLD:
-            self._name_counts = self._collect_name_counts()
             self._build_position_index()
 
     def insert(self, index: SupportsIndex, item: Node) -> None:  # type: ignore[override]
@@ -1067,14 +1068,11 @@ class _CountingStack(list[Node]):
         name = item.name
         if name == "p":
             self._p_count += 1
-        counts = self._name_counts
-        if counts is not None:
-            counts[name] = counts.get(name, 0) + 1
-        elif len(self) >= _STACK_COUNT_THRESHOLD:
-            self._name_counts = self._collect_name_counts()
-            # Crossing the threshold has to build the position index too. Every
-            # other path treats a live `_name_counts` as proof the index exists.
+        if not was_indexed and len(self) >= _STACK_COUNT_THRESHOLD:
+            # Crossing the threshold has to index here too, or the next push
+            # reads position lists that were never built.
             self._build_position_index()
+            return
         if was_indexed:
             if normalized_index == length:
                 self._note_top_position(item, normalized_index)
@@ -1094,10 +1092,6 @@ class _CountingStack(list[Node]):
                 self._p_count -= 1
             if name == "p":
                 self._p_count += 1
-            counts = self._name_counts
-            if counts is not None:
-                counts[previous_name] -= 1
-                counts[name] = counts.get(name, 0) + 1
         if self._indexed:
             # One slot changing hands moves nothing, so only the two nodes
             # involved are re-recorded. Rebuilding the whole index costs the
@@ -1112,9 +1106,6 @@ class _CountingStack(list[Node]):
         name = item.name
         if name == "p":
             self._p_count -= 1
-        counts = self._name_counts
-        if counts is not None:
-            counts[name] -= 1
         if self._indexed:
             if normalized_index == len(self):
                 self._forget_top_position(item, normalized_index)
@@ -1131,9 +1122,6 @@ class _CountingStack(list[Node]):
         name = item.name
         if name == "p":
             self._p_count -= 1
-        counts = self._name_counts
-        if counts is not None:
-            counts[name] -= 1
         if self._indexed:
             if index == len(self):
                 self._forget_top_position(item, index)
@@ -1155,13 +1143,9 @@ class _CountingStack(list[Node]):
         removed = self[key] if isinstance(key, slice) else [self[key]]
         list.__delitem__(self, key)
         p_count = self._p_count
-        counts = self._name_counts
         for item in removed:
-            name = item.name
-            if name == "p":
+            if item.name == "p":
                 p_count -= 1
-            if counts is not None:
-                counts[name] -= 1
         self._p_count = p_count
         if self._indexed:
             if normalized_index is None:
@@ -2598,7 +2582,7 @@ class ParseEngine:
             and stack[-1].name == name
             and stack[-1] is not self._fragment_context_node
         ):
-            if stack._name_counts is None:
+            if not stack._indexed:
                 list.pop(stack)
                 if name == "p":
                     stack._p_count -= 1
@@ -2622,7 +2606,7 @@ class ParseEngine:
                     and entry.name == name
                     and stack[-1] is entry.node
                 ):
-                    if stack._name_counts is None:
+                    if not stack._indexed:
                         list.pop(stack)
                     else:
                         stack.pop()
@@ -2714,7 +2698,7 @@ class ParseEngine:
             if idx is None:
                 return pos
             self._mark_active_formatting_dirty()
-            if stack._name_counts is None and not stack._p_count:
+            if not stack._indexed and not stack._p_count:
                 list.__delitem__(stack, slice(idx, None))
             else:
                 del stack[idx:]
@@ -2730,7 +2714,7 @@ class ParseEngine:
         ):
             if name in _TABLE_CELL_TAGS or name in _ACTIVE_FORMATTING_MARKER_TAGS:
                 self._clear_active_formatting_to_marker()
-            if stack._name_counts is None:
+            if not stack._indexed:
                 list.pop(stack)
                 if name == "p":
                     stack._p_count -= 1
@@ -2789,7 +2773,7 @@ class ParseEngine:
             self._clear_active_formatting_to_marker()
         elif name in _ACTIVE_FORMATTING_MARKER_TAGS:  # pragma: no branch - opposite edge requires invalid parser state
             self._clear_active_formatting_to_marker()  # pragma: no cover - unreachable after parser-state guards
-        if stack._name_counts is None and not stack._p_count:
+        if not stack._indexed and not stack._p_count:
             list.__delitem__(stack, slice(idx, None))
         else:
             del stack[idx:]
@@ -3288,7 +3272,7 @@ class ParseEngine:
             current_parent.children.append(node)  # type: ignore[union-attr]
             node.parent = current_parent
             if not is_void:
-                if name == "p" or stack._name_counts is not None or len(stack) >= _STACK_COUNT_THRESHOLD - 1:
+                if name == "p" or stack._indexed or len(stack) >= _STACK_COUNT_THRESHOLD - 1:
                     stack.append(node)
                 else:
                     list.append(stack, node)
@@ -4159,7 +4143,7 @@ class ParseEngine:
             self._insert_at(foster_parent, position, node)
         if not is_void:
             stack = self._stack
-            if name == "p" or stack._name_counts is not None or len(stack) >= _STACK_COUNT_THRESHOLD - 1:
+            if name == "p" or stack._indexed or len(stack) >= _STACK_COUNT_THRESHOLD - 1:
                 stack.append(node)
             else:
                 list.append(stack, node)

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -487,6 +487,10 @@ class TestCountingStack(unittest.TestCase):
         assert namesakes.last_template_boundary_index() == -1
         assert engine._open_parser_only_template_index() is None
 
+        no_namesakes = _CountingStack([root, *filler])
+        engine._stack = no_namesakes
+        assert engine._open_parser_only_template_index() is None
+
     def test_indexed_parser_only_positions_follow_middle_mutations(self) -> None:
         root = DocumentFragment()
         filler = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD)]

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -583,7 +583,7 @@ class TestCountingStack(unittest.TestCase):
         del stack[:]
         self.assert_counts_match(stack)
 
-    def test_deep_stack_keeps_the_name_map_after_shrinking(self) -> None:
+    def test_deep_stack_keeps_the_position_index_after_shrinking(self) -> None:
         stack = _CountingStack(Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD))
         assert stack._indexed
 

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -9,7 +9,11 @@ from justhtml.dom import DocumentFragment, Element, Template, Text
 from justhtml.parser.context import FragmentContext
 from justhtml.parser.engine import (
     _AFTER_BODY,
+    _DEFAULT_SCOPE_BOUNDARIES,
+    _GENERAL_END_TAG_BOUNDARIES,
+    _P_SCOPE_BOUNDARIES,
     _STACK_COUNT_THRESHOLD,
+    _TABLE_CONTEXT_BOUNDARIES,
     _UNWRAP_BATCH_THRESHOLD,
     ParseEngine,
     _CountingStack,
@@ -279,6 +283,76 @@ class TestCountingStack(unittest.TestCase):
             for length in (1, 2, 5, len(ordered)):
                 nodes = [DocumentFragment()] + [make() for make in ordered[:length]]
                 self.assert_indexed_and_scanned_agree(nodes)
+
+    def test_engine_scope_helpers_agree_across_indexed_and_scanned_stacks(self) -> None:
+        """The scope check keeps a shallow single-pass path beside the indexed one.
+
+        Both must give the same answer, or a document would parse differently
+        once its stack crossed the depth at which the index is built.
+        """
+        shapes = [
+            ["div", "p", "span"],
+            ["div", "button", "p", "b"],
+            ["table", "tbody", "tr", "td", "div", "p"],
+            ["div", "li", "div", "ul", "li"],
+            ["template", "div", "table", "p"],
+            ["h1", "div", "span"],
+            ["div", "svg:svg", "svg:foreignObject", "div", "svg:g"],
+            ["div", "math:math", "math:annotation-xml", "span"],
+            ["p", "svg:svg", "svg:g", "svg:g"],
+            ["div", "parser-only:template", "p", "span"],
+        ]
+
+        def build(names):
+            nodes = [DocumentFragment()]
+            for entry in names:
+                if entry.startswith("parser-only:"):
+                    nodes.append(Element(entry.split(":")[1], {}, "justhtml-parser-only"))
+                elif ":" in entry:
+                    namespace, local = entry.split(":")
+                    attrs = {"encoding": "text/html"} if local == "annotation-xml" else {}
+                    nodes.append(Element(local, attrs, namespace))
+                elif entry == "template":
+                    nodes.append(Template("template", {}, namespace="html"))
+                else:
+                    nodes.append(Element(entry, {}, "html"))
+            return nodes
+
+        boundary_sets = [
+            _P_SCOPE_BOUNDARIES,
+            _DEFAULT_SCOPE_BOUNDARIES,
+            _GENERAL_END_TAG_BOUNDARIES,
+            _TABLE_CONTEXT_BOUNDARIES,
+            frozenset({"template"}),
+        ]
+        probe_names = ["p", "div", "li", "span", "table", "td", "b", "g", "foreignObject", "missing"]
+
+        for shape in shapes:
+            nodes = build(shape)
+            scanned = _CountingStack(nodes)
+            assert not scanned._indexed
+            indexed = self._indexed_copy(nodes)
+
+            engine = ParseEngine("", fragment=True)
+            for name in probe_names:
+                for boundaries in boundary_sets:
+                    engine._stack = scanned
+                    scanned_result = engine._find_open_index_before_boundary(name, boundaries)
+                    engine._stack = indexed
+                    assert scanned_result == engine._find_open_index_before_boundary(name, boundaries), (
+                        shape,
+                        name,
+                        sorted(boundaries)[:3],
+                    )
+                for boundaries in boundary_sets:
+                    assert scanned.last_scope_boundary_index(boundaries) == indexed.last_scope_boundary_index(
+                        boundaries
+                    ), (shape, boundaries)
+
+            engine._stack = scanned
+            scanned_heading = engine._find_open_heading_index()
+            engine._stack = indexed
+            assert scanned_heading == engine._find_open_heading_index(), shape
 
     def assert_index_matches_contents(self, stack: _CountingStack) -> None:
         """Every ascending list the stack maintains must still describe it."""

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -111,6 +111,16 @@ class TestActiveFormattingScaling(unittest.TestCase):
         for shape in shapes:
             assert_scales_linearly(shape, lambda source: JustHTML(source, sanitize=False))
 
+    def test_adoption_cloning_a_nested_formatting_element_scales_linearly(self) -> None:
+        """A formatting element between the subject and the furthest block.
+
+        The inner loop clones it and writes the clone back into the middle of
+        the open-elements stack, once per repetition, on a stack that grows with
+        the input. The control has the same element count with nothing to clone.
+        """
+        assert_scales_linearly(lambda size: "<b><i><div></b>" * size, JustHTML)
+        assert_scales_linearly(lambda size: "<b><div></b>" * size, JustHTML)
+
 
 class TestDiagnosticScaling(unittest.TestCase):
     def test_basic_error_collection_scales_linearly(self) -> None:
@@ -329,6 +339,26 @@ class TestCountingStack(unittest.TestCase):
         for node in reversed(stack[len(filler) + 1 : len(filler) + 4]):
             stack.remove(node)
             self.assert_index_matches_contents(stack)
+
+    def test_replacing_a_node_re_records_only_that_slot(self) -> None:
+        """Swapping one entry moves nothing, so the rest of the index stands."""
+        root = DocumentFragment()
+        filler = [Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD)]
+        boundary = Element("foreignObject", {}, "svg")
+        stack = _CountingStack([root, *filler, boundary, Element("span", {}, "html")])
+        assert stack._indexed
+
+        replacement = Element("g", {}, "svg")
+        stack[len(filler) + 1] = replacement
+        self.assert_index_matches_contents(stack)
+        assert stack.index_of_node(replacement) == len(filler) + 1
+        assert stack.index_of_node(boundary) is None
+        assert stack.last_foreign_boundary_index() == -1
+
+        same_name = Element("g", {}, "svg")
+        stack[len(filler) + 1] = same_name
+        self.assert_index_matches_contents(stack)
+        assert stack.index_of_node(same_name) == len(filler) + 1
 
     def test_insert_that_crosses_the_depth_threshold_builds_the_index(self) -> None:
         """Growing past the threshold through `insert` must index, like `append`.

--- a/tests/test_parser_engine.py
+++ b/tests/test_parser_engine.py
@@ -219,9 +219,6 @@ class TestCountingStack(unittest.TestCase):
     def _indexed_copy(nodes: list) -> _CountingStack:
         """Build a stack that answers from the index regardless of its depth."""
         stack = _CountingStack(nodes)
-        counts = stack._collect_name_counts()
-        stack._name_counts = counts
-        stack._p_count = counts.get("p", 0)
         stack._build_position_index()
         return stack
 
@@ -437,7 +434,7 @@ class TestCountingStack(unittest.TestCase):
     def test_insert_that_crosses_the_depth_threshold_builds_the_index(self) -> None:
         """Growing past the threshold through `insert` must index, like `append`.
 
-        Every other path treats a live `_name_counts` as proof that the position
+        Every other path treats `_indexed` as proof that the position
         index exists, so setting one without the other leaves the next push
         reading attributes that were never assigned.
         """
@@ -557,8 +554,9 @@ class TestCountingStack(unittest.TestCase):
         assert stack.count_of("div") == expected["div"]
         assert stack.count_of("span") == expected["span"]
         assert stack.count_of("missing") == 0
-        if stack._name_counts is not None:
-            assert {name: count for name, count in stack._name_counts.items() if count} == expected
+        # Counts are derived from the position lists rather than stored, so
+        # every name on the stack has to come back exact.
+        assert {name: stack.count_of(name) for name in expected} == dict(expected)
 
     def test_shallow_stack_tracks_parser_mutations_without_a_name_map(self) -> None:
         div = Element("div", {}, "html")
@@ -566,7 +564,7 @@ class TestCountingStack(unittest.TestCase):
         second_p = Element("p", {}, "html")
         span = Element("span", {}, "html")
         stack = _CountingStack([div, first_p])
-        assert stack._name_counts is None
+        assert not stack._indexed
 
         stack.append(second_p)
         stack.insert(1, span)
@@ -587,7 +585,7 @@ class TestCountingStack(unittest.TestCase):
 
     def test_deep_stack_keeps_the_name_map_after_shrinking(self) -> None:
         stack = _CountingStack(Element("div", {}, "html") for _ in range(_STACK_COUNT_THRESHOLD))
-        assert stack._name_counts is not None
+        assert stack._indexed
 
         p = Element("p", {}, "html")
         span = Element("span", {}, "html")
@@ -601,7 +599,7 @@ class TestCountingStack(unittest.TestCase):
         self.assert_counts_match(stack)
 
         del stack[1:]
-        assert stack._name_counts is not None
+        assert stack._indexed
         stack.append(Element("span", {}, "html"))
         self.assert_counts_match(stack)
 
@@ -670,7 +668,7 @@ class TestCountingStack(unittest.TestCase):
         engine = ParseEngine("<div>" * _STACK_COUNT_THRESHOLD + "<b><i><p>1</b>2</i>", fragment=True)
         engine.parse()
 
-        assert engine._stack._name_counts is not None
+        assert engine._stack._indexed
         self.assert_counts_match(engine._stack)
 
     def test_compiled_end_tag_fast_paths_keep_shallow_and_deep_counts_exact(self) -> None:


### PR DESCRIPTION
## Summary

This fixes a quadratic parser regression introduced with the adaptive open-elements index in 3.10.0, then reduces the bookkeeping and repeated lookups on the same stack:

- Re-record only the replaced slot when the adoption agency clones a formatting element, instead of rebuilding every position list.
- Reject absent scope targets from the maintained count before searching for a boundary.
- Use one bounded pass for target and boundary on shallow stacks, while retaining indexed lookups for deep stacks.
- Derive indexed name counts from the existing HTML/foreign position buckets, retaining only the especially hot `p` count.
- Avoid parser-only template lookups when foster parenting cannot need them, reuse namespace sets, and query heading names together.

These changes are combined because they alter the same `_CountingStack` query and mutation invariants. The final implementation also avoids landing the scope guard with a second general-purpose name-count map that the later optimization immediately removes.

## Shipped regression

For `"<b><i><div></b>" * 4000`, seven alternating fresh-process rounds on Python 3.14.6 measured:

| Revision | Median |
| --- | ---: |
| v3.10.1 | 1,959.1 ms |
| This PR | 46.0 ms |

That is a 42.6x speedup. In the earlier same-machine three-version run, 3.9.0 took 562 ms, v3.10.1 took 2,088 ms, and this implementation took 43 ms, confirming that the unfixed state is a regression rather than only an adversarial optimization opportunity.

The scaling regression test exercises both the cloning shape and an element-count-matched control.

## Broader performance

I used the more extensive `optimize-foster-stack-lookups` benchmark suite as the comparison basis: 48 black-box parser/DOM/serializer scenarios with controls, calibrated inner loops, GC disabled during samples, fitted growth exponents, and noise/regression gates. I rebased that implementation onto `04e761bf6ca45a54125f26ccf2aff01a88104c56` and compared it with v3.10.1 plus this PR using interleaved tree order.

On 1,000 fixed in-memory web100k documents, 12 paired passes with two rotated rounds per tree produced these geometric-mean ratios (`this PR / rebased reference`, lower is faster):

| Pipeline | Ratio | Bootstrap 95% CI |
| --- | ---: | ---: |
| Default parse | 1.0019 | 0.9961..1.0069 |
| Parse + compact HTML | 1.0023 | 0.9958..1.0094 |
| Parse + pretty HTML | 1.0035 | 0.9997..1.0071 |

A separate 300-document, 16-pass matrix found the two implementations equivalent with error collection (`0.9960`, CI `0.9862..1.0043`) and streaming (`0.9968`, CI `0.9905..1.0020`). The rebased reference was 1.55% faster for raw parsing and 1.31% faster for raw parse + compact serialization in that smaller matrix.

Neither stack layout wins every focused shape. This PR was faster on the table, adoption, selected-content, and button-scope cases; the rebased reference was faster on foreign-boundary and some deep-control cases. Across two full balanced scaling runs, all 48 scenarios remained linear in both implementations with no exponent regression. A final exact-tree smoke over the 12 adoption/scope/foster scenarios at `n=500,1000,2000,4000`, seven samples per size, also passed every linearity guard.

## Correctness and resource checks

- Full WPT/html5lib/project suite: 3,956/3,956 passing, 6 skipped, 100% statement and branch coverage.
- Ruff check/format and mypy pass.
- 1,000 deterministic `_CountingStack` differential seeds, 400 mutations per seed, agree with the underlying list and rebuilt indexes.
- 3,000 generated deep documents agree across sanitization and error-collection modes.
- Pretty and compact output for 1,000 web100k documents is byte-identical between implementations.
- Both implementations parse the 50,000-deep frameset probe at the default recursion limit and reach the same 131,072-element scaling-guard ceiling.
- Peak RSS was within approximately 1%.