### PR TITLE
fix: Keep whitespace at inline element boundaries in Markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (Severity: Low) Re-record only the slot that changed when the adoption agency clones a formatting element back onto the open-elements stack, instead of rebuilding the whole position index. Since 3.10.0, markup nesting a formatting element between the end tag's subject and the furthest block, such as `"<b><i><div></b>" * n`, took time quadratic in its length -- about 3.7x longer than 3.9.0 on the same input.
 
+### Fixed
+
+- Keep the collapsed space that sits just inside `a`, `b`, `strong`, `em`, and `i` when `to_markdown()` renders their content, so `<p>This is <b>very </b>important.</p>` becomes `This is **very** important.` rather than `This is **very**important.`, which renders as one word. A separating space is never written directly after output that already ends in one, so leading whitespace inside a heading or list item, as in `<ul><li> Item</li></ul>` or `<ul><li><b> </b>Item</li></ul>`, no longer widens the `- ` marker to `-  ` and shifts the item's content out of alignment with a nested list.
+
 ## [3.10.1] - 2026-07-25
 
 ### Performance

--- a/src/justhtml/serializer/markdown.py
+++ b/src/justhtml/serializer/markdown.py
@@ -153,14 +153,16 @@ def _markdown_link_destination(url: str) -> str:
 
 
 class _MarkdownBuilder:
-    __slots__ = ("_buf", "_newline_count", "_pending_space")
+    __slots__ = ("_buf", "_leading_space", "_newline_count", "_pending_space")
 
     _buf: list[str]
+    _leading_space: bool
     _newline_count: int
     _pending_space: bool
 
     def __init__(self) -> None:
         self._buf = []
+        self._leading_space = False
         self._newline_count = 0
         self._pending_space = False
 
@@ -193,7 +195,12 @@ class _MarkdownBuilder:
         # we still need to emit a single separating space.
         if self._pending_space:
             first = s[0]
-            if first not in HTML_SPACE_CHARACTERS and self._buf and self._newline_count == 0:
+            if (
+                first not in HTML_SPACE_CHARACTERS
+                and self._buf
+                and self._newline_count == 0
+                and not self._buf[-1].endswith((" ", "\t"))
+            ):
                 self._buf.append(" ")
             self._pending_space = False
 
@@ -229,12 +236,14 @@ class _MarkdownBuilder:
         while index < length:
             ch = s[index]
             if ch in HTML_SPACE_CHARACTERS:
+                if not self._buf:
+                    self._leading_space = True
                 self._pending_space = True
                 index += 1
                 continue
 
             if self._pending_space:
-                if self._buf and self._newline_count == 0:
+                if self._buf and self._newline_count == 0 and not self._buf[-1].endswith((" ", "\t")):
                     self._buf.append(" ")
                 self._pending_space = False
 
@@ -538,6 +547,8 @@ def _to_markdown_walk(
         if kind == "after_marker":
             parent_builder, inner_builder, marker = task[1], task[2], task[3]
             content = inner_builder.finish()
+            if inner_builder._leading_space:
+                parent_builder.text(" ")
             if content:
                 if "\n" in content:
                     parent_builder.ensure_newlines(2 if parent_builder._buf else 0)
@@ -546,11 +557,15 @@ def _to_markdown_walk(
                 parent_builder.raw(marker)
                 parent_builder.raw(content)
                 parent_builder.raw(marker)
+            if inner_builder._pending_space:
+                parent_builder.text(" ")
             continue
 
         if kind == "after_link":
             parent_builder, inner_builder, href = task[1], task[2], task[3]
             link_text = inner_builder.finish()
+            if inner_builder._leading_space:
+                parent_builder.text(" ")
             parent_builder.raw("[")
             parent_builder.raw(link_text)
             parent_builder.raw("]")
@@ -558,6 +573,8 @@ def _to_markdown_walk(
                 parent_builder.raw("(")
                 parent_builder.raw(_markdown_link_destination(href))
                 parent_builder.raw(")")
+            if inner_builder._pending_space:
+                parent_builder.text(" ")
             continue
 
         if kind != "after_block_container":  # pragma: no cover

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -461,6 +461,68 @@ class TestNode(unittest.TestCase):
         assert md.startswith("# Title\n\n")
         assert "Hello **world** *ok* [link](https://e.com) a\\*b" in md
 
+    def test_to_markdown_keeps_space_after_inline_element_content(self):
+        doc = JustHTML("<p>This is <b>very </b>important. See <em>the docs </em>for details.</p>")
+        spaced = JustHTML("<p>This is <b>very </b> important.</p>")
+
+        assert doc.to_markdown() == "This is **very** important. See *the docs* for details."
+        assert spaced.to_markdown() == "This is **very** important."
+
+    def test_to_markdown_keeps_space_before_inline_element_content(self):
+        doc = JustHTML("<p>Read<b> the docs</b> and<span> the guide</span> today.</p>")
+
+        assert doc.to_markdown() == "Read **the docs** and the guide today."
+
+    def test_to_markdown_keeps_space_at_link_text_boundaries(self):
+        trailing = JustHTML("<p>Visit <a href='https://e.com'>our site </a>today.</p>")
+        leading = JustHTML("<p>Visit<a href='https://e.com'> our site</a> today.</p>")
+
+        assert trailing.to_markdown() == "Visit [our site](https://e.com) today."
+        assert leading.to_markdown() == "Visit [our site](https://e.com) today."
+
+    def test_to_markdown_keeps_one_space_between_marker_and_inline_element(self):
+        heading = JustHTML("<h2><b> x</b>y</h2>")
+        unordered = JustHTML("<ul><li><b> x</b>y</li></ul>")
+        ordered = JustHTML("<ol><li><b> x</b>y</li></ol>")
+        in_link = JustHTML("<a href='https://e.com'>z<ul><li><b> x</b>y</li></ul></a>")
+
+        assert heading.to_markdown() == "## **x**y"
+        assert unordered.to_markdown() == "- **x**y"
+        assert ordered.to_markdown() == "1. **x**y"
+        assert in_link.to_markdown() == "[z **x**y](https://e.com)"
+
+    def test_to_markdown_keeps_space_after_inline_element_under_a_marker(self):
+        heading = JustHTML("<h2><b>x </b>y</h2>")
+        item = JustHTML("<ul><li><b>x </b>y</li></ul>")
+
+        assert heading.to_markdown() == "## **x** y"
+        assert item.to_markdown() == "- **x** y"
+
+    def test_to_markdown_keeps_nested_list_indented_under_its_item(self):
+        doc = JustHTML("<ul><li><b> outer</b><ul><li>inner</li></ul></li><li>second</li></ul>")
+        empty_inline = JustHTML("<ul><li><b> </b>outer<ul><li>inner</li></ul></li><li>second</li></ul>")
+
+        assert doc.to_markdown() == "- **outer**\n\n  - inner\n\n\n- second"
+        assert empty_inline.to_markdown() == "- outer\n\n  - inner\n\n\n- second"
+
+    def test_to_markdown_renders_whitespace_only_inline_element_as_one_space(self):
+        item = JustHTML("<ul><li><b> </b>Item text</li></ul>")
+        heading = JustHTML("<h2><b> </b>Title</h2>")
+        paragraph = JustHTML("<p>Item<b> </b>text</p>")
+        link = JustHTML("<p>Item<a href='https://e.com'> </a>text</p>")
+
+        assert item.to_markdown() == "- Item text"
+        assert heading.to_markdown() == "## Title"
+        assert paragraph.to_markdown() == "Item text"
+        assert link.to_markdown() == "Item [](https://e.com) text"
+
+    def test_to_markdown_keeps_one_space_between_marker_and_leading_text_space(self):
+        item = JustHTML("<ul><li> Item</li></ul>")
+        heading = JustHTML("<h2> Title</h2>")
+
+        assert item.to_markdown() == "- Item"
+        assert heading.to_markdown() == "## Title"
+
     def test_to_markdown_code_inline_and_block(self):
         doc = JustHTML("<pre>code`here\n</pre><p>inline <code>a`b</code></p>")
         md = doc.to_markdown()


### PR DESCRIPTION
`to_markdown()` drops the space that sits just inside an inline element, welding the words on either side together. `to_text()` on the same input is correct, and so is `<span>`, which makes the two spellings of the same document disagree.

| input | `to_text()` | `to_markdown()` | renders as |
|---|---|---|---|
| `<p>This is <b>very </b>important.</p>` | `This is very important.` | `This is **very**important.` | `This is <strong>very</strong>important.` |
| `<p>Visit <a href="https://e.com">our site </a>today.</p>` | `Visit our site today.` | `Visit [our site](https://e.com)today.` | `…</a>today.` |
| `<p>See <em>the docs </em>for details.</p>` | `See the docs for details.` | `See *the docs*for details.` | `…</em>for details.` |
| `<p>Visit<a href="https://e.com"> our site</a> today.</p>` | `Visit our site today.` | `Visit[our site](https://e.com) today.` | `Visit<a…>` |

This is the shape a rich-text editor produces when the user's selection includes the trailing space, so it shows up in pasted content rather than in hand-written HTML.

## Cause

`a`, `em`, `i`, `strong` and `b` render their children into a separate `_MarkdownBuilder`, so the boundary whitespace never reaches the parent. A trailing space is still sitting in the child's `_pending_space` when `finish()` runs, and a leading space is discarded because the child's buffer is empty at that point. `<span>` and the other inline containers share the parent builder and go through `_pending_space` normally, which is why they already came out right.

## Fix

Record on the builder whether whitespace was collapsed before any output, and re-emit both boundaries into the parent when the marker or link is closed.

Re-emitting alone injects a *second* space after a structural marker: both places the builder can flush a pending space, `raw()` and `text()`, appended one whenever the buffer was non-empty without checking what it ended with — and headings and list items write `"## "`, `"- "` and `"1. "` through `raw()`. In a list that destroys structure rather than spacing. The extra space moves the item content to column 3 while nested lists indent by 2, so the inner list in

```html
<ul><li><b> outer</b><ul><li>inner</li></ul></li><li>second</li></ul>
```

no longer clears its parent item and renders as a flat sibling. Both flushes now skip a buffer that already ends in a space or tab.

I put the guard in the builder rather than at the two re-emission sites deliberately: the re-emissions work *because* they are ordinary `text(" ")` calls, which is what lets a boundary space collapse against adjacent text, disappear at block and document ends, and propagate outward through nested inline elements such as `<a>x <b>y </b></a>z`. Guarding at the call sites would have meant four copies of the check reaching into `parent_builder._buf`, and would have left the rule false for the other `text(" ")` callers. Happy to switch if you'd rather have it the other way.

The predicate also covers whitespace that predates this change, so `<ul><li> Item</li></ul>` now renders `- Item` instead of `-  Item`, and `<h2> Title</h2>` renders `## Title`. Both render identically in CommonMark; where the column does matter, for a nested list, the new output is the correct one. That is pinned by a test so the change is deliberate rather than incidental.

## Tests

Eight tests in `tests/test_node.py` alongside the other `to_markdown` cases, covering both directions: the space that must appear at an inline boundary, and the space that must **not** appear after a `##`/`- `/`1. ` marker or inside `flatten_list_item`. The nested-list test asserts the exact string, including the existing blank-line shape, so a future regression in either direction fails.

I checked each test fails without the corresponding part of the change — the boundary tests fail on `main`, and the marker tests fail against an earlier revision of this branch that had the re-emission without the guard.

Verified on `main` at `fdab7f5`:

- `python run_tests.py` — **3965/3965 passed (100.0%), 6 skipped**; baseline on `main` is 3957/3957, so +8 is exactly the new tests
- `coverage run run_tests.py && coverage report` — **100%**, statements and branches, with both new conditions exercised in both directions
- `ruff check`, `ruff format --check`, `mypy src` — clean
- `benchmarks/html5lib_engine_diff.py --fail-under-rate 1.0 --fail-on-current-exceptions` — exit 0

I also ran a differential over ~68,000 generated cases (inline elements × whitespace shapes including empty and whitespace-only content × block contexts, in both compact and `html_passthrough` mode), comparing output against `main`. Every difference is either a separating space restored at an element boundary or a duplicate space collapsed — no case differs in a non-whitespace character, none loses a separator `main` had, and none gains a double space.

One thing I noticed while testing and deliberately left alone: `<ol>` nested-list indentation is already off on `main` (`1. a\n\n  1. n` flattens under CommonMark, because a 2-space indent doesn't clear an ordered marker's content column). It's unrelated to this change and unaffected by it — happy to file it separately if useful.

*Disclosure: written with AI assistance (Claude Code). Every repro and every number above was executed locally against this branch; I've reviewed the change and can speak to it.*
