### PR TITLE
fix: Preserve Markdown inline boundary spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disallowed foreign content back into the output, where SVG or MathML event handlers could execute.
 - (Severity: Low) Re-record only the slot that changed when the adoption agency clones a formatting element back onto the open-elements stack, instead of rebuilding the whole position index. Since 3.10.0, markup nesting a formatting element between the end tag's subject and the furthest block, such as `"<b><i><div></b>" * n`, took time quadratic in its length -- about 3.7x longer than 3.9.0 on the same input.
 
+### Fixed
+
+- Preserve collapsed whitespace at `a`, `b`, `strong`, `em`, and `i` boundaries in Markdown output without adding
+  duplicate spaces after heading or list markers.
+
 ## [3.10.1] - 2026-07-25
 
 ### Performance

--- a/src/justhtml/serializer/markdown.py
+++ b/src/justhtml/serializer/markdown.py
@@ -156,16 +156,18 @@ _MAX_BLOCKQUOTE_DEPTH = 64
 
 
 class _MarkdownBuilder:
-    __slots__ = ("_blockquote_depth", "_buf", "_newline_count", "_pending_space")
+    __slots__ = ("_blockquote_depth", "_buf", "_leading_space", "_newline_count", "_pending_space")
 
     _buf: list[str]
     _blockquote_depth: int
     _newline_count: int
     _pending_space: bool
+    _leading_space: bool
 
     def __init__(self, blockquote_depth: int = 0) -> None:
         self._buf = []
         self._blockquote_depth = blockquote_depth
+        self._leading_space = False
         self._newline_count = 0
         self._pending_space = False
 
@@ -198,7 +200,12 @@ class _MarkdownBuilder:
         # we still need to emit a single separating space.
         if self._pending_space:
             first = s[0]
-            if first not in HTML_SPACE_CHARACTERS and self._buf and self._newline_count == 0:
+            if (
+                first not in HTML_SPACE_CHARACTERS
+                and self._buf
+                and self._newline_count == 0
+                and not self._buf[-1].endswith((" ", "\t"))
+            ):
                 self._buf.append(" ")
             self._pending_space = False
 
@@ -234,12 +241,14 @@ class _MarkdownBuilder:
         while index < length:
             ch = s[index]
             if ch in HTML_SPACE_CHARACTERS:
+                if not self._buf:
+                    self._leading_space = True
                 self._pending_space = True
                 index += 1
                 continue
 
             if self._pending_space:
-                if self._buf and self._newline_count == 0:
+                if self._buf and self._newline_count == 0 and not self._buf[-1].endswith((" ", "\t")):
                     self._buf.append(" ")
                 self._pending_space = False
 
@@ -442,7 +451,7 @@ def _to_markdown_walk(
                 continue
 
             if tag in {"em", "i"}:
-                inner_builder = _MarkdownBuilder()
+                inner_builder = _MarkdownBuilder(current_builder._blockquote_depth)
                 tasks.append(("after_marker", current_builder, inner_builder, "*"))
                 tasks.extend(
                     ("visit", child, inner_builder, False, current_list_depth, current_in_link)
@@ -451,7 +460,7 @@ def _to_markdown_walk(
                 continue
 
             if tag in {"strong", "b"}:
-                inner_builder = _MarkdownBuilder()
+                inner_builder = _MarkdownBuilder(current_builder._blockquote_depth)
                 tasks.append(("after_marker", current_builder, inner_builder, "**"))
                 tasks.extend(
                     ("visit", child, inner_builder, False, current_list_depth, current_in_link)
@@ -463,7 +472,7 @@ def _to_markdown_walk(
                 href = ""
                 if current.attrs and "href" in current.attrs and current.attrs["href"] is not None:
                     href = str(current.attrs["href"])
-                inner_builder = _MarkdownBuilder()
+                inner_builder = _MarkdownBuilder(current_builder._blockquote_depth)
                 tasks.append(("after_link", current_builder, inner_builder, href))
                 tasks.extend(
                     ("visit", child, inner_builder, False, current_list_depth, True)
@@ -548,6 +557,8 @@ def _to_markdown_walk(
         if kind == "after_marker":
             parent_builder, inner_builder, marker = task[1], task[2], task[3]
             content = inner_builder.finish()
+            if inner_builder._leading_space:
+                parent_builder.text(" ")
             if content:
                 if "\n" in content:
                     parent_builder.ensure_newlines(2 if parent_builder._buf else 0)
@@ -556,11 +567,15 @@ def _to_markdown_walk(
                 parent_builder.raw(marker)
                 parent_builder.raw(content)
                 parent_builder.raw(marker)
+            if inner_builder._pending_space:
+                parent_builder.text(" ")
             continue
 
         if kind == "after_link":
             parent_builder, inner_builder, href = task[1], task[2], task[3]
             link_text = inner_builder.finish()
+            if inner_builder._leading_space:
+                parent_builder.text(" ")
             parent_builder.raw("[")
             parent_builder.raw(link_text)
             parent_builder.raw("]")
@@ -568,6 +583,8 @@ def _to_markdown_walk(
                 parent_builder.raw("(")
                 parent_builder.raw(_markdown_link_destination(href))
                 parent_builder.raw(")")
+            if inner_builder._pending_space:
+                parent_builder.text(" ")
             continue
 
         if kind != "after_block_container":  # pragma: no cover

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -507,6 +507,60 @@ class TestNode(unittest.TestCase):
         doc = JustHTML("<blockquote><p>Q<br>R</p></blockquote>")
         assert doc.to_markdown() == "> Q\n> R"
 
+    def test_to_markdown_keeps_inline_boundary_spaces(self):
+        trailing = JustHTML("<p>This is <b>very </b>important. See <em>the docs </em>for details.</p>")
+        leading = JustHTML("<p>Visit<a href='https://e.com'> our site</a> today.</p>")
+        already_spaced = JustHTML("<p>This is <b>very </b> important.</p>")
+
+        assert trailing.to_markdown() == "This is **very** important. See *the docs* for details."
+        assert leading.to_markdown() == "Visit [our site](https://e.com) today."
+        assert already_spaced.to_markdown() == "This is **very** important."
+
+    def test_to_markdown_collapses_boundary_spaces_after_structural_markers(self):
+        heading = JustHTML("<h2><b> x</b>y</h2>")
+        unordered = JustHTML("<ul><li><b> x</b>y</li></ul>")
+        ordered = JustHTML("<ol><li><b> x</b>y</li></ol>")
+        in_link = JustHTML("<a href='https://e.com'>z<ul><li><b> x</b>y</li></ul></a>")
+
+        assert heading.to_markdown() == "## **x**y"
+        assert unordered.to_markdown() == "- **x**y"
+        assert ordered.to_markdown() == "1. **x**y"
+        assert in_link.to_markdown() == "[z **x**y](https://e.com)"
+
+    def test_to_markdown_keeps_trailing_inline_space_after_structural_markers(self):
+        heading = JustHTML("<h2><b>x </b>y</h2>")
+        item = JustHTML("<ul><li><b>x </b>y</li></ul>")
+
+        assert heading.to_markdown() == "## **x** y"
+        assert item.to_markdown() == "- **x** y"
+
+    def test_to_markdown_keeps_nested_list_under_boundary_spaced_item(self):
+        doc = JustHTML("<ul><li><b> outer</b><ul><li>inner</li></ul></li><li>second</li></ul>")
+        empty_inline = JustHTML("<ul><li><b> </b>outer<ul><li>inner</li></ul></li><li>second</li></ul>")
+
+        assert doc.to_markdown() == "- **outer**\n\n  - inner\n\n\n- second"
+        assert empty_inline.to_markdown() == "- outer\n\n  - inner\n\n\n- second"
+
+    def test_to_markdown_renders_whitespace_only_inline_element_as_one_space(self):
+        item = JustHTML("<ul><li><b> </b>Item text</li></ul>")
+        heading = JustHTML("<h2><b> </b>Title</h2>")
+        paragraph = JustHTML("<p>Item<b> </b>text</p>")
+        link = JustHTML("<p>Item<a href='https://e.com'> </a>text</p>")
+
+        assert item.to_markdown() == "- Item text"
+        assert heading.to_markdown() == "## Title"
+        assert paragraph.to_markdown() == "Item text"
+        assert link.to_markdown() == "Item [](https://e.com) text"
+
+    def test_to_markdown_collapses_leading_text_space_after_structural_marker(self):
+        assert JustHTML("<ul><li> Item</li></ul>").to_markdown() == "- Item"
+        assert JustHTML("<h2> Title</h2>").to_markdown() == "## Title"
+
+    def test_to_markdown_inline_builders_preserve_blockquote_depth(self):
+        html = "<blockquote><b>" * 100 + "<p>x</p>"
+
+        assert JustHTML(html).to_markdown().count("> ") == 64
+
     def test_to_markdown_bounds_nested_blockquote_prefixes(self):
         doc = JustHTML("<blockquote>" * 100 + "<p>x</p>")
 


### PR DESCRIPTION
## Summary

Preserve collapsed whitespace that appears just inside `a`, `b`, `strong`, `em`, and `i` elements when serializing to Markdown. This reimplements the behavior reported in #78 against the current Markdown builder.

The fix records leading and trailing collapsed whitespace in child builders and feeds it back through the parent builder's ordinary whitespace handling. It also avoids duplicate spaces after heading and list markers.

Inline child builders inherit the active blockquote depth, so formatting and link elements cannot reset the existing bound on deeply nested blockquote prefixes.

## User impact

Rich-text HTML such as `<p>This is <b>very </b>important.</p>` now serializes as `This is **very** important.` instead of joining the surrounding words. Equivalent link and emphasis boundaries behave consistently.

## Validation

- `pre-commit run --all-files`
- 100% test coverage
- parser differential at 100%
- focused Markdown and DOM test suite
