### PR TITLE
🐛 fix(bench): qualify TurboHTML foreign attributes

### DIFF
--- a/benchmarks/correctness.py
+++ b/benchmarks/correctness.py
@@ -16,6 +16,7 @@ import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Final
 
 from justhtml import JustHTML
 from justhtml.parser.context import FragmentContext
@@ -577,6 +578,19 @@ NS_MATHML = "http://www.w3.org/1998/Math/MathML"
 NS_XLINK = "http://www.w3.org/1999/xlink"
 NS_XML = "http://www.w3.org/XML/1998/namespace"
 NS_XMLNS = "http://www.w3.org/2000/xmlns/"
+_TURBOHTML_FOREIGN_ATTRIBUTE_NAMES: Final[dict[str, str]] = {
+    "xlink:actuate": "xlink actuate",
+    "xlink:arcrole": "xlink arcrole",
+    "xlink:href": "xlink href",
+    "xlink:role": "xlink role",
+    "xlink:show": "xlink show",
+    "xlink:title": "xlink title",
+    "xlink:type": "xlink type",
+    "xml:lang": "xml lang",
+    "xml:space": "xml space",
+    "xmlns": "xmlns xmlns",
+    "xmlns:xlink": "xmlns xlink",
+}
 
 
 def _serialize_lxml_document_siblings(root, etree):
@@ -914,14 +928,15 @@ def _turbohtml_to_test_format(nodes, indent):
             return f"math {name}"
         return name
 
-    def attribute_name(name):
-        if name.startswith("xlink:"):
-            return f"xlink {name.removeprefix('xlink:')}"
-        if name.startswith("xml:"):
-            return f"xml {name.removeprefix('xml:')}"
-        if name.startswith("xmlns:"):
-            return f"xmlns {name.removeprefix('xmlns:')}"
-        return name
+    def attribute_name(namespace, name):
+        if namespace not in {Namespace.SVG, Namespace.MATHML}:
+            return name
+        return _TURBOHTML_FOREIGN_ATTRIBUTE_NAMES.get(name, name)
+
+    def attribute_value(value):
+        if isinstance(value, list):
+            return " ".join(value)
+        return value or ""
 
     def process(node, node_indent):
         prefix = " " * node_indent
@@ -939,8 +954,10 @@ def _turbohtml_to_test_format(nodes, indent):
             return [line for child in node.children for line in process(child, node_indent)]
 
         lines = [f"| {prefix}<{qualified_name(node.namespace, node.tag)}>"]
-        for name, value in sorted(node.attrs.items()):
-            lines.append(f'| {prefix}  {attribute_name(name)}="{value}"')
+        for name, value in sorted(
+            (attribute_name(node.namespace, name), attribute_value(value)) for name, value in node.attrs.items()
+        ):
+            lines.append(f'| {prefix}  {name}="{value}"')
 
         if node.tag == "template" and node.namespace is Namespace.HTML:
             lines.append(f"| {prefix}  content")

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -13,7 +13,7 @@ Use a different tool when one narrow requirement matters more than the whole pip
 | **JustHTML**<br>Pure Python | ✅ 100% | ⚡ Fast | ✅ CSS selectors | ✅ `element()` | ✅ Built-in | Correct, secure, easy to install, and fast enough. |
 | **`selectolax`**<br>Python wrapper of C-based Lexbor | ✅ 100% | 🚀 Very Fast | ✅ CSS selectors | ✅ `create_node()` | ❌ Needs sanitization | Very fast. |
 | **Chromium**<br>browser engine | 🟡 95.0% [2] | 🚀 Very Fast | — | — | — | Current browser-harness result. |
-| **`turbohtml`**<br>Python wrapper of a C core | 🟡 94.2% | 🚀 Very Fast | ✅ CSS selectors, XPath | ✅ `E.*` builder | ✅ Built-in | Broad, compiled alternative with parsing, querying, and sanitization. |
+| **`turbohtml`**<br>Python wrapper of a C core | 🟡 94.8% | 🚀 Very Fast | ✅ CSS selectors, XPath | ✅ `E.*` builder | ✅ Built-in | Broad, compiled alternative with parsing, querying, and sanitization. |
 | **WebKit**<br>browser engine | 🟡 93.9% [2] | 🚀 Very Fast | — | — | — | Current browser-harness result. |
 | **Firefox**<br>browser engine | 🟡 93.1% [2] | 🚀 Very Fast | — | — | — | Current browser-harness result. |
 | **`html5lib`**<br>Pure Python | 🟡 82.3% | 🐢 Slow | 🟡 XPath (lxml) | 🟡 Tree API | 🔴 [Deprecated](https://github.com/html5lib/html5lib-python/issues/443) | Unmaintained reference implementation; incomplete coverage of the tree-construction fixtures. |


### PR DESCRIPTION
TurboHTML's public DOM preserves lexical attribute names and exposes token-list values as lists. The correctness adapter treated every `xlink:`, `xml:`, and `xmlns:` spelling as namespace-adjusted and rendered token lists through Python's representation, so 11 matching WPT trees counted as failures. This corrects the external collaboration item in [tox-dev/turbohtml#720](https://github.com/tox-dev/turbohtml/issues/720).

The formatter emits namespace-qualified names only for the WHATWG foreign-attribute adjustment list on SVG and MathML elements. It preserves ordinary HTML and unknown foreign prefixed names, joins token-list values with spaces, and sorts attributes after conversion to the html5lib test format.

The pinned run at JustHTML `13ab469`, TurboHTML 1.4.0, and WPT `4830edb` records 1,782/1,880 (94.79%), up from 1,771/1,880 (94.20%). The comparison table reports 94.8%.
